### PR TITLE
docs(olids): add Compass Equivalent column to schema docs

### DIFF
--- a/OLIDS/Documentation/Schema/Allergy_Intolerance.md
+++ b/OLIDS/Documentation/Schema/Allergy_Intolerance.md
@@ -27,7 +27,7 @@ Substances include, but are not limited to: a therapeutic substance administered
 | `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
 | `PRACTITIONER_ID` | `UUID` | linked practitioner id. | FK -> [PRACTITIONER](Practitioner.md).ID | `practitioner_id` |
 | `ENCOUNTER_ID` | `UUID` | linked encounter id. | FK -> [ENCOUNTER](Encounter.md).ID | `encounter_id` |
-| `CLINICAL_STATUS` | `VARCHAR` | clinical status. | - | `clinical_status` |
+| `CLINICAL_STATUS` | `VARCHAR` | clinical status. | - | -- |
 | `VERIFICATION_STATUS` | `VARCHAR` | verification status. | - | -- |
 | `CATEGORY` | `VARCHAR` | category. | - | -- |
 | `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | - | `clinical_effective_date` |

--- a/OLIDS/Documentation/Schema/Allergy_Intolerance.md
+++ b/OLIDS/Documentation/Schema/Allergy_Intolerance.md
@@ -16,35 +16,35 @@ Substances include, but are not limited to: a therapeutic substance administered
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | - |
-| `PATIENT_ID` | `UUID` | linked patient identifier | FK -> [PATIENT](Patient.md).ID |
-| `PERSON_ID` | `UUID` | linked person id. | FK -> [PERSON](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PRACTITIONER_ID` | `UUID` | linked practitioner id. | FK -> [PRACTITIONER](Practitioner.md).ID |
-| `ENCOUNTER_ID` | `UUID` | linked encounter id. | FK -> [ENCOUNTER](Encounter.md).ID |
-| `CLINICAL_STATUS` | `VARCHAR` | clinical status. | - |
-| `VERIFICATION_STATUS` | `VARCHAR` | verification status. | - |
-| `CATEGORY` | `VARCHAR` | category. | - |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | - |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | lds concept id date precision. | FK -> [CONCEPT](concept.md).ID |
-| `IS_REVIEW` | `BOOLEAN` | is review. | - |
-| `MEDICATION_NAME` | `VARCHAR` | medication name. | - |
-| `MULTI_LEX_ACTION` | `VARCHAR` | multi lex action. | - |
-| `ALLERGY_INTOLERANCE_SOURCE_CONCEPT_ID` | `UUID` | allergy intolerance source concept id. | FK -> [CONCEPT](concept.md).ID |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | - |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | - |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | - |
-| `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | - |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | - |
-| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | - |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | - |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | The timestamp when the record was supplied to, or acquired by, LDS. | - |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | - | -- |
+| `PATIENT_ID` | `UUID` | linked patient identifier | FK -> [PATIENT](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | linked person id. | FK -> [PERSON](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `PRACTITIONER_ID` | `UUID` | linked practitioner id. | FK -> [PRACTITIONER](Practitioner.md).ID | `practitioner_id` |
+| `ENCOUNTER_ID` | `UUID` | linked encounter id. | FK -> [ENCOUNTER](Encounter.md).ID | `encounter_id` |
+| `CLINICAL_STATUS` | `VARCHAR` | clinical status. | - | `clinical_status` |
+| `VERIFICATION_STATUS` | `VARCHAR` | verification status. | - | -- |
+| `CATEGORY` | `VARCHAR` | category. | - | -- |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | - | `clinical_effective_date` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | lds concept id date precision. | FK -> [CONCEPT](concept.md).ID | `date_precision_concept_id` |
+| `IS_REVIEW` | `BOOLEAN` | is review. | - | `is_review` |
+| `MEDICATION_NAME` | `VARCHAR` | medication name. | - | -- |
+| `MULTI_LEX_ACTION` | `VARCHAR` | multi lex action. | - | -- |
+| `ALLERGY_INTOLERANCE_SOURCE_CONCEPT_ID` | `UUID` | allergy intolerance source concept id. | FK -> [CONCEPT](concept.md).ID | `non_core_concept_id` |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | - | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | - | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | - | -- |
+| `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | - | `date_recorded` |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | - | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | - | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | - | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | The timestamp when the record was supplied to, or acquired by, LDS. | - | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Appointment.md
+++ b/OLIDS/Documentation/Schema/Appointment.md
@@ -20,44 +20,44 @@ This definition takes the concepts of appointments in a clinical setting and als
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `VARCHAR` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `VARCHAR` | lds record id. |  |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `SLOT_ID` | `UUID` | linked identifier for the slot | <not yet linked> |
-| `PRACTITIONER_IN_ROLE_ID` | `UUID` | practitioner in role id. | FK -> [Practitioner_In_Role](Practitioner_In_Role.md).ID |
-| `SCHEDULE_ID` | `UUID` | schedule id. | FK -> [Schedule](Schedule.md).ID |
-| `START_DATE` | `TIMESTAMP` | start date. | |
-| `PLANNED_DURATION_MINS` | `NUMBER` | planned duration. | |
-| `ACTUAL_DURATION_MINS` | `NUMBER` | actual duration. | |
-| `APPOINTMENT_STATUS_SOURCE_CONCEPT_ID` | `UUID` | appointment status concept id. | FK -> [CONCEPT](concept.md).ID|
-| `PATIENT_WAIT_MINS` | `NUMBER` | patient wait. | |
-| `PATIENT_DELAY_MINS` | `NUMBER` | patient delay. | |
-| `DATETIME_BOOKED` | `TIMESTAMP_NTZ` | date time booked. | |
-| `DATETIME_SENT_IN` | `TIMESTAMP_NTZ` | date time sent in. | |
-| `DATETIME_LEFT` | `TIMESTAMP_NTZ` | date time left. | |
-| `CANCELLED_DATE` | `VARCHAR` (SHOULD BE DATE) | cancelled date. | |
-| `APPOINTMENT_TYPE` | `VARCHAR` | type of appointment. | |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at date of event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at date of event. NULL where patient is over 1 years old. | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at date of event. NULL where patient is over 27 days old. | |
-| `BOOKING_METHOD_SOURCE_CONCEPT_ID` | `UUID` | booking method concept id. | FK -> [CONCEPT](concept.md).ID|
-| `CONTACT_MODE_SOURCE_CONCEPT_ID` | `UUID` | contact mode concept id. | FK -> [CONCEPT](concept.md).ID|
-| `IS_BLOCKED` | `BOOLEAN` | is blocked. | |
-| `NATIONAL_SLOT_CATEGORY_NAME` | `VARCHAR` | national slot category name. | |
-| `CONTEXT_TYPE` | `VARCHAR` | context type. | |
-| `SERVICE_SETTING` | `VARCHAR` | service setting. | |
-| `NATIONAL_SLOT_CATEGORY_DESCRIPTION` | `VARCHAR` | national slot category description. | |
-| `CSDS_CARE_CONTACT_IDENTIFIER` | `VARCHAR` | csds care contact identifier. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes th data. |  |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `VARCHAR` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `VARCHAR` | lds record id. |  | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `SLOT_ID` | `UUID` | linked identifier for the slot | <not yet linked> | -- |
+| `PRACTITIONER_IN_ROLE_ID` | `UUID` | practitioner in role id. | FK -> [Practitioner_In_Role](Practitioner_In_Role.md).ID | `practitioner_id` |
+| `SCHEDULE_ID` | `UUID` | schedule id. | FK -> [Schedule](Schedule.md).ID | `schedule_id` |
+| `START_DATE` | `TIMESTAMP` | start date. | | `start_date` |
+| `PLANNED_DURATION_MINS` | `NUMBER` | planned duration. | | `planned_duration` |
+| `ACTUAL_DURATION_MINS` | `NUMBER` | actual duration. | | `actual_duration` |
+| `APPOINTMENT_STATUS_SOURCE_CONCEPT_ID` | `UUID` | appointment status concept id. | FK -> [CONCEPT](concept.md).ID| `appointment_status_concept_id` |
+| `PATIENT_WAIT_MINS` | `NUMBER` | patient wait. | | `patient_wait` |
+| `PATIENT_DELAY_MINS` | `NUMBER` | patient delay. | | `patient_delay` |
+| `DATETIME_BOOKED` | `TIMESTAMP_NTZ` | date time booked. | | -- |
+| `DATETIME_SENT_IN` | `TIMESTAMP_NTZ` | date time sent in. | | `date_time_sent_in` |
+| `DATETIME_LEFT` | `TIMESTAMP_NTZ` | date time left. | | `date_time_left` |
+| `CANCELLED_DATE` | `VARCHAR` (SHOULD BE DATE) | cancelled date. | | `cancelled_date` |
+| `APPOINTMENT_TYPE` | `VARCHAR` | type of appointment. | | -- |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at date of event. | | -- |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at date of event. NULL where patient is over 1 years old. | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at date of event. NULL where patient is over 27 days old. | | -- |
+| `BOOKING_METHOD_SOURCE_CONCEPT_ID` | `UUID` | booking method concept id. | FK -> [CONCEPT](concept.md).ID| -- |
+| `CONTACT_MODE_SOURCE_CONCEPT_ID` | `UUID` | contact mode concept id. | FK -> [CONCEPT](concept.md).ID| -- |
+| `IS_BLOCKED` | `BOOLEAN` | is blocked. | | -- |
+| `NATIONAL_SLOT_CATEGORY_NAME` | `VARCHAR` | national slot category name. | | -- |
+| `CONTEXT_TYPE` | `VARCHAR` | context type. | | -- |
+| `SERVICE_SETTING` | `VARCHAR` | service setting. | | -- |
+| `NATIONAL_SLOT_CATEGORY_DESCRIPTION` | `VARCHAR` | national slot category description. | | -- |
+| `CSDS_CARE_CONTACT_IDENTIFIER` | `VARCHAR` | csds care contact identifier. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes th data. |  | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Appointment_Practitioner.md
+++ b/OLIDS/Documentation/Schema/Appointment_Practitioner.md
@@ -16,22 +16,22 @@ List of practitioner participants involved in an appointment.
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | unique and consistent identifier for the entity | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform. | |
-| `PATIENT_ID` | `UUID` | linked patient identifier | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | linked person identifier | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `APPOINTMENT_ID` | `UUID` | linked appointment id. | FK -> [Appointment](Appointment.md).ID |
-| `PRACTITIONER_ID` | `UUID` | linked practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `LDS_SOURCE_RECORD_ID_PRACTITIONER` | `UUID` | A unique identifier denoting the originating base-record prior to transform. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | The timestamp when the record was supplied to, or acquired by, LDS. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | LDS transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | unique and consistent identifier for the entity | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform. | | -- |
+| `PATIENT_ID` | `UUID` | linked patient identifier | FK -> [Patient](Patient.md).ID | -- |
+| `PERSON_ID` | `UUID` | linked person identifier | FK -> [Person](Person.md).ID | -- |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `APPOINTMENT_ID` | `UUID` | linked appointment id. | FK -> [Appointment](Appointment.md).ID | -- |
+| `PRACTITIONER_ID` | `UUID` | linked practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `LDS_SOURCE_RECORD_ID_PRACTITIONER` | `UUID` | A unique identifier denoting the originating base-record prior to transform. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | The timestamp when the record was supplied to, or acquired by, LDS. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | LDS transform date time. | | -- |
 
 ## Entity relationship
 

--- a/OLIDS/Documentation/Schema/Diagnostic_Order.md
+++ b/OLIDS/Documentation/Schema/Diagnostic_Order.md
@@ -16,39 +16,39 @@ The resource allows requesting only a single procedure. If a workflow requires r
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | Unique business identifier for the diagnostic order record. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `PARENT_OBSERVATION_ID` | `UUID` | parent observation id. | FK -> [OBSERVATION](Observation.md).ID |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | |
-| `DATE_PRECISION_RAW` | `VARCHAR` | date precision raw. | |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | source concept id for date precision. | [CONCEPT](Concept.md).ID |
-| `RESULT_VALUE` | `DOUBLE` | result value. | |
-| `RESULT_MEASUREMENT_UNITS_SOURCE_CONCEPT_ID` | `UUID` | source concept id for result measurementunits. | [CONCEPT](Concept.md).ID |
-| `RESULT_DATE` | `DATE` | result date. | |
-| `RESULT_TEXT` | `INTEGER` | result text. | |
-| `IS_PROBLEM` | `BOOLEAN` | is problem. | |
-| `IS_REVIEW` | `BOOLEAN` | is review. | |
-| `PROBLEM_END_DATE` | `DATE` | problem end date. | |
-| `DIAGNOSTIC_ORDER_SOURCE_CONCEPT_ID` | `UUID` | source concept id for the diagnostic order. | [CONCEPT](Concept.md).ID |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | |
-| `EPISODICITY_SOURCE_CONCEPT_ID` | `UUID` | source concept id for episodicity. | [CONCEPT](Concept.md).ID |
-| `IS_PRIMARY` | `BOOLEAN` | is primary. | |
-| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | The timestamp when the record was supplied to, or acquired by, LDS. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | Unique business identifier for the diagnostic order record. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | `encounter_id` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `PARENT_OBSERVATION_ID` | `UUID` | parent observation id. | FK -> [OBSERVATION](Observation.md).ID | `parent_observation_id` |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
+| `DATE_PRECISION_RAW` | `VARCHAR` | date precision raw. | | -- |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | source concept id for date precision. | [CONCEPT](Concept.md).ID | `date_precision_concept_id` |
+| `RESULT_VALUE` | `DOUBLE` | result value. | | `result_value` |
+| `RESULT_MEASUREMENT_UNITS_SOURCE_CONCEPT_ID` | `UUID` | source concept id for result measurementunits. | [CONCEPT](Concept.md).ID | `result_value_units_concept_id` |
+| `RESULT_DATE` | `DATE` | result date. | | `result_date` |
+| `RESULT_TEXT` | `INTEGER` | result text. | | `result_text` |
+| `IS_PROBLEM` | `BOOLEAN` | is problem. | | `is_problem` |
+| `IS_REVIEW` | `BOOLEAN` | is review. | | `is_review` |
+| `PROBLEM_END_DATE` | `DATE` | problem end date. | | `problem_end_date` |
+| `DIAGNOSTIC_ORDER_SOURCE_CONCEPT_ID` | `UUID` | source concept id for the diagnostic order. | [CONCEPT](Concept.md).ID | `raw_concept_id` |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | | `age_at_event_baby` |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | | `age_at_event_neonate` |
+| `EPISODICITY_SOURCE_CONCEPT_ID` | `UUID` | source concept id for episodicity. | [CONCEPT](Concept.md).ID | `episodicity_concept_id` |
+| `IS_PRIMARY` | `BOOLEAN` | is primary. | | `is_primary` |
+| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | | `date_recorded` |
+| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | The timestamp when the record was supplied to, or acquired by, LDS. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity relations
 

--- a/OLIDS/Documentation/Schema/Diagnostic_Order.md
+++ b/OLIDS/Documentation/Schema/Diagnostic_Order.md
@@ -32,16 +32,16 @@ The resource allows requesting only a single procedure. If a workflow requires r
 | `DATE_PRECISION_RAW` | `VARCHAR` | date precision raw. | | -- |
 | `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | source concept id for date precision. | [CONCEPT](Concept.md).ID | `date_precision_concept_id` |
 | `RESULT_VALUE` | `DOUBLE` | result value. | | `result_value` |
-| `RESULT_MEASUREMENT_UNITS_SOURCE_CONCEPT_ID` | `UUID` | source concept id for result measurementunits. | [CONCEPT](Concept.md).ID | `result_value_units_concept_id` |
+| `RESULT_MEASUREMENT_UNITS_SOURCE_CONCEPT_ID` | `UUID` | source concept id for result measurementunits. | [CONCEPT](Concept.md).ID | `result_value_units` |
 | `RESULT_DATE` | `DATE` | result date. | | `result_date` |
 | `RESULT_TEXT` | `INTEGER` | result text. | | `result_text` |
 | `IS_PROBLEM` | `BOOLEAN` | is problem. | | `is_problem` |
 | `IS_REVIEW` | `BOOLEAN` | is review. | | `is_review` |
 | `PROBLEM_END_DATE` | `DATE` | problem end date. | | `problem_end_date` |
-| `DIAGNOSTIC_ORDER_SOURCE_CONCEPT_ID` | `UUID` | source concept id for the diagnostic order. | [CONCEPT](Concept.md).ID | `raw_concept_id` |
+| `DIAGNOSTIC_ORDER_SOURCE_CONCEPT_ID` | `UUID` | source concept id for the diagnostic order. | [CONCEPT](Concept.md).ID | `non_core_concept_id` |
 | `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | | `age_at_event_baby` |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | | `age_at_event_neonate` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | | -- |
 | `EPISODICITY_SOURCE_CONCEPT_ID` | `UUID` | source concept id for episodicity. | [CONCEPT](Concept.md).ID | `episodicity_concept_id` |
 | `IS_PRIMARY` | `BOOLEAN` | is primary. | | `is_primary` |
 | `DATE_RECORDED` | `TIMESTAMP` | date recorded. | | `date_recorded` |

--- a/OLIDS/Documentation/Schema/Encounter.md
+++ b/OLIDS/Documentation/Schema/Encounter.md
@@ -20,8 +20,8 @@ A patient encounter is further characterized by the setting in which it takes pl
 | `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | <MISSING> | -- |
 | `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
 | `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID | `organisation_id` |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `service_provider_organisation_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `service_provider_organization_id` |
 | `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
 | `EPISODE_OF_CARE_ID` | `UUID` | episode of care id. | FK -> [Episode_Of_Care](Episode_Of_Care.md).ID | `episode_of_care_id` |
 | `APPOINTMENT_ID` | `UUID` | appointment id. | FK -> [Appointment](Appointment.md).ID | `appointment_id` |

--- a/OLIDS/Documentation/Schema/Encounter.md
+++ b/OLIDS/Documentation/Schema/Encounter.md
@@ -14,35 +14,35 @@ A patient encounter is further characterized by the setting in which it takes pl
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | Unique business identifier for the entity. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | <MISSING> |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `EPISODE_OF_CARE_ID` | `UUID` | episode of care id. | FK -> [Episode_Of_Care](Episode_Of_Care.md).ID |
-| `APPOINTMENT_ID` | `UUID` | appointment id. | FK -> [Appointment](Appointment.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `LOCATION` | `VARCHAR` | location. | |
-| `ENCOUNTER_SOURCE_CONCEPT_ID` | `UUID` | encounter source concept id. | FK -> [Concept](Concept.md).ID |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK -> [Concept](Concept.md).ID |
-| `CONSULTATION_TYPE` | `VARCHAR` | consultation type. | |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | |
-| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | |
-| `TYPE` | `VARCHAR` | type. | |
-| `SUBTYPE` | `VARCHAR` | subtype. | |
-| `ADMISSION_METHOD` | `VARCHAR` | admission method. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | Unique business identifier for the entity. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | A unique identifier denoting the originating base-record prior to transform | <MISSING> | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID | `organisation_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `service_provider_organisation_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `EPISODE_OF_CARE_ID` | `UUID` | episode of care id. | FK -> [Episode_Of_Care](Episode_Of_Care.md).ID | `episode_of_care_id` |
+| `APPOINTMENT_ID` | `UUID` | appointment id. | FK -> [Appointment](Appointment.md).ID | `appointment_id` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `LOCATION` | `VARCHAR` | location. | | `institution_location_id` |
+| `ENCOUNTER_SOURCE_CONCEPT_ID` | `UUID` | encounter source concept id. | FK -> [Concept](Concept.md).ID | `non_core_concept_id` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK -> [Concept](Concept.md).ID | `date_precision_concept_id` |
+| `CONSULTATION_TYPE` | `VARCHAR` | consultation type. | | -- |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
+| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | | `date_recorded` |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | | -- |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | | -- |
+| `TYPE` | `VARCHAR` | type. | | `type` |
+| `SUBTYPE` | `VARCHAR` | subtype. | | `sub_type` |
+| `ADMISSION_METHOD` | `VARCHAR` | admission method. | | `admission_method` |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity relationship
 

--- a/OLIDS/Documentation/Schema/Episode_Of_Care.md
+++ b/OLIDS/Documentation/Schema/Episode_Of_Care.md
@@ -12,27 +12,27 @@ An association between a patient and an organisation / healthcare provider(s) du
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | Unique business identifier for the entity. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID |
-| `MANAGING_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `MANAGING_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who is responsible for care delivery within the episode of care. | |
-| `USUAL_GP_PRACTITIONER_IN_ROLE_ID` | `UUID` | usual gp practitioner in role id. | FK -> [Practitioner_In_Role](Practitioner_In_Role.md).ID |
-| `EPISODE_OF_CARE_START_DATE` | `DATE` | episode of care start date. | |
-| `EPISODE_OF_CARE_END_DATE` | `DATE` | episode of care end date. | |
-| `TYPE` | `VARCHAR` | type. | <to be removed> |
-| `EPISODE_TYPE_SOURCE_CONCEPT_ID` | `UUID` | episode type source concept id. | FK -> [Concept](Concept.md).ID |
-| `STATUS` | `VARCHAR` | status. | <to be removed> |
-| `EPISODE_STATUS_SOURCE_CONCEPT_ID` | `UUID` | episode status source concept id. | FK -> [Concept](Concept.md).ID |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | Unique business identifier for the entity. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id). | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `MANAGING_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `MANAGING_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who is responsible for care delivery within the episode of care. | | -- |
+| `USUAL_GP_PRACTITIONER_IN_ROLE_ID` | `UUID` | usual gp practitioner in role id. | FK -> [Practitioner_In_Role](Practitioner_In_Role.md).ID | `usual_gp_practitioner_id` |
+| `EPISODE_OF_CARE_START_DATE` | `DATE` | episode of care start date. | | `date_registered` |
+| `EPISODE_OF_CARE_END_DATE` | `DATE` | episode of care end date. | | `date_registered_end` |
+| `TYPE` | `VARCHAR` | type. | <to be removed> | -- |
+| `EPISODE_TYPE_SOURCE_CONCEPT_ID` | `UUID` | episode type source concept id. | FK -> [Concept](Concept.md).ID | `registration_type_concept_id` |
+| `STATUS` | `VARCHAR` | status. | <to be removed> | -- |
+| `EPISODE_STATUS_SOURCE_CONCEPT_ID` | `UUID` | episode status source concept id. | FK -> [Concept](Concept.md).ID | `registration_status_concept_id` |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Location.md
+++ b/OLIDS/Documentation/Schema/Location.md
@@ -14,30 +14,30 @@ A Location includes both incidental locations (a place which is used for healthc
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | |
-| `NAME` | `VARCHAR` | name. | |
-| `LOCATION_TYPE_SOURCE_CONCEPT_ID` | `UUID` | type code. | FK -> [Concept](Concept.md).ID |
-| `TYPE_DESCRIPTION` | `VARCHAR` | type description. | |
-| `IS_PRIMARY_LOCATION` | `BOOLEAN` | is primary location. | |
-| `HOUSE_NAME` | `VARCHAR` | house name. | |
-| `HOUSE_NUMBER` | `VARCHAR` | house number. | |
-| `HOUSE_NAME_FLAT_NUMBER` | `VARCHAR` | house name flat number. | |
-| `STREET` | `VARCHAR` | street. | |
-| `ADDRESS_LINE_1` | `VARCHAR` | address line 1. | |
-| `ADDRESS_LINE_2` | `VARCHAR` | address line 2. | |
-| `ADDRESS_LINE_3` | `VARCHAR` | address line 3. | |
-| `ADDRESS_LINE_4` | `VARCHAR` | address line 4. | |
-| `POSTCODE` | `VARCHAR` | postcode. | |
-| `MANAGING_ORGANISATION_ID` | `UUID` | managing organisation id. | FK -> [Organisation](Organisation.md).ID |
-| `OPEN_DATE` | `DATE` | open date. | |
-| `CLOSE_DATE` | `DATE` | close date. | |
-| `IS_OBSOLETE` | `BOOLEAN` | is obsolete. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | | -- |
+| `NAME` | `VARCHAR` | name. | | `name` |
+| `LOCATION_TYPE_SOURCE_CONCEPT_ID` | `UUID` | type code. | FK -> [Concept](Concept.md).ID | `type_code` |
+| `TYPE_DESCRIPTION` | `VARCHAR` | type description. | | `type_desc` |
+| `IS_PRIMARY_LOCATION` | `BOOLEAN` | is primary location. | | -- |
+| `HOUSE_NAME` | `VARCHAR` | house name. | | -- |
+| `HOUSE_NUMBER` | `VARCHAR` | house number. | | -- |
+| `HOUSE_NAME_FLAT_NUMBER` | `VARCHAR` | house name flat number. | | -- |
+| `STREET` | `VARCHAR` | street. | | -- |
+| `ADDRESS_LINE_1` | `VARCHAR` | address line 1. | | -- |
+| `ADDRESS_LINE_2` | `VARCHAR` | address line 2. | | -- |
+| `ADDRESS_LINE_3` | `VARCHAR` | address line 3. | | -- |
+| `ADDRESS_LINE_4` | `VARCHAR` | address line 4. | | -- |
+| `POSTCODE` | `VARCHAR` | postcode. | | `postcode` |
+| `MANAGING_ORGANISATION_ID` | `UUID` | managing organisation id. | FK -> [Organisation](Organisation.md).ID | `managing_organization_id` |
+| `OPEN_DATE` | `DATE` | open date. | | -- |
+| `CLOSE_DATE` | `DATE` | close date. | | -- |
+| `IS_OBSOLETE` | `BOOLEAN` | is obsolete. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Medication_Order.md
+++ b/OLIDS/Documentation/Schema/Medication_Order.md
@@ -22,44 +22,44 @@ The MedicationRequest resource allows requesting only a single medication. If a 
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider^1^. | FK -> [Organisation](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID |
-| `MEDICATION_STATEMENT_ID` | `UUID` | medication statement id. | FK -> [Medication_Statement](Medication_Statement.md).ID |
-| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `OBSERVATION_ID` | `UUID` | observation id. | FK -> [Observation](Observation.md).ID |
-| `ALLERGY_INTOLERANCE_ID` | `UUID` | allergy intolerance id. | FK -> [Allergy_Intolerance](Allergy_Intolerance.md).ID |
-| `DIAGNOSTIC_ORDER_ID` | `UUID` | diagnostic order id. | FK -> [Diagnostic_Order](Diagnostic_Order.md).ID |
-| `REFERRAL_REQUEST_ID` | `UUID` | referral request id. | FK -> [Referral_Request](Referral_Request.md).ID |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK -> [Concept](Concept.md).ID |
-| `DOSE` | `VARCHAR` | dose. | |
-| `QUANTITY_VALUE` | `FLOAT` | quantity value. | |
-| `QUANTITY_VALUE_DESCRIPTION` | `VARCHAR` | quantity value description. | |
-| `QUANTITY_UNIT` | `VARCHAR` | quantity unit. | |
-| `DURATION_DAYS` | `NUMBER` | duration days. | |
-| `ESTIMATED_COST` | `NUMBER` | estimated cost. | |
-| `MEDICATION_NAME` | `VARCHAR` | medication name. | |
-| `MEDICATION_ORDER_SOURCE_CONCEPT_ID` | `UUID` | medication order source concept id. | FK -> [Concept](Concept.md).ID |
-| `BNF_REFERENCE` | `VARCHAR` | bnf reference. | |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | |
-| `ISSUE_METHOD` | `VARCHAR` | issue method. | |
-| `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | |
-| `ISSUE_METHOD_DESCRIPTION` | `VARCHAR` | issue method description. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider^1^. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `MEDICATION_STATEMENT_ID` | `UUID` | medication statement id. | FK -> [Medication_Statement](Medication_Statement.md).ID | `medication_statement_id` |
+| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | -- |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `OBSERVATION_ID` | `UUID` | observation id. | FK -> [Observation](Observation.md).ID | -- |
+| `ALLERGY_INTOLERANCE_ID` | `UUID` | allergy intolerance id. | FK -> [Allergy_Intolerance](Allergy_Intolerance.md).ID | -- |
+| `DIAGNOSTIC_ORDER_ID` | `UUID` | diagnostic order id. | FK -> [Diagnostic_Order](Diagnostic_Order.md).ID | -- |
+| `REFERRAL_REQUEST_ID` | `UUID` | referral request id. | FK -> [Referral_Request](Referral_Request.md).ID | -- |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK -> [Concept](Concept.md).ID | `date_precision_concept_id` |
+| `DOSE` | `VARCHAR` | dose. | | `dose` |
+| `QUANTITY_VALUE` | `FLOAT` | quantity value. | | `quantity_value` |
+| `QUANTITY_VALUE_DESCRIPTION` | `VARCHAR` | quantity value description. | | -- |
+| `QUANTITY_UNIT` | `VARCHAR` | quantity unit. | | `quantity_unit` |
+| `DURATION_DAYS` | `NUMBER` | duration days. | | `duration_days` |
+| `ESTIMATED_COST` | `NUMBER` | estimated cost. | | `estimated_cost` |
+| `MEDICATION_NAME` | `VARCHAR` | medication name. | | -- |
+| `MEDICATION_ORDER_SOURCE_CONCEPT_ID` | `UUID` | medication order source concept id. | FK -> [Concept](Concept.md).ID | `non_core_concept_id` |
+| `BNF_REFERENCE` | `VARCHAR` | bnf reference. | | `bnf_reference` |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | | -- |
+| `ISSUE_METHOD` | `VARCHAR` | issue method. | | `issue_method` |
+| `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | | `date_recorded` |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | | -- |
+| `ISSUE_METHOD_DESCRIPTION` | `VARCHAR` | issue method description. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 1. See the [schema notes section on publisher, provider, author organisation definitions](_schema_notes.md#provider-author-publisher-organisation-id)
 

--- a/OLIDS/Documentation/Schema/Medication_Statement.md
+++ b/OLIDS/Documentation/Schema/Medication_Statement.md
@@ -16,44 +16,44 @@ The primary difference between a medicationstatement and a medicationadministrat
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider^1^. | FK -> [Organisation](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID |
-| `OBSERVATION_ID` | `UUID` | observation id. | FK -> [Observation](Observation.md).ID |
-| `ALLERGY_INTOLERANCE_ID` | `UUID` | allergy intolerance id. | FK -> [Allergy_Intolerance](Allergy_Intolerance.md).ID |
-| `DIAGNOSTIC_ORDER_ID` | `UUID` | diagnostic order id. | FK -> [Diagnostic_Order](Diagnostic_Order.md).ID |
-| `REFERRAL_REQUEST_ID` | `UUID` | referral request id. | FK -> [Referral_Request](Referral_Request.md).ID |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK -> [Concept](Concept.md).ID |
-| `CANCELLATION_DATE` | `DATE` | cancellation date. | |
-| `DOSE` | `VARCHAR` | dose. | |
-| `QUANTITY_VALUE_DESCRIPTION` | `VARCHAR` | quantity value description. | |
-| `QUANTITY_VALUE` | `DOUBLE` | quantity value. | |
-| `QUANTITY_UNIT` | `VARCHAR` | quantity unit. | |
-| `AUTHORISATION_TYPE_SOURCE_CONCEPT_ID` | `UUID` | authorisation type concept id. | FK -> [Concept](Concept.md).ID |
-| `MEDICATION_NAME` | `VARCHAR` | medication name. | |
-| `MEDICATION_STATEMENT_SOURCE_CONCEPT_ID` | `UUID` | medication statement source concept id. | FK -> [Concept](Concept.md).ID |
-| `BNF_REFERENCE` | `VARCHAR` | bnf reference. | |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | |
-| `ISSUE_METHOD` | `VARCHAR` | issue method. | |
-| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | |
-| `IS_ACTIVE` | `BOOLEAN` | is active. | |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | |
-| `EXPIRY_DATE` | `DATE` | expiry date. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider^1^. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | `encounter_id` |
+| `OBSERVATION_ID` | `UUID` | observation id. | FK -> [Observation](Observation.md).ID | -- |
+| `ALLERGY_INTOLERANCE_ID` | `UUID` | allergy intolerance id. | FK -> [Allergy_Intolerance](Allergy_Intolerance.md).ID | -- |
+| `DIAGNOSTIC_ORDER_ID` | `UUID` | diagnostic order id. | FK -> [Diagnostic_Order](Diagnostic_Order.md).ID | -- |
+| `REFERRAL_REQUEST_ID` | `UUID` | referral request id. | FK -> [Referral_Request](Referral_Request.md).ID | -- |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK -> [Concept](Concept.md).ID | `date_precision_concept_id` |
+| `CANCELLATION_DATE` | `DATE` | cancellation date. | | `cancellation_date` |
+| `DOSE` | `VARCHAR` | dose. | | `dose` |
+| `QUANTITY_VALUE_DESCRIPTION` | `VARCHAR` | quantity value description. | | -- |
+| `QUANTITY_VALUE` | `DOUBLE` | quantity value. | | `quantity_value` |
+| `QUANTITY_UNIT` | `VARCHAR` | quantity unit. | | `quantity_unit` |
+| `AUTHORISATION_TYPE_SOURCE_CONCEPT_ID` | `UUID` | authorisation type concept id. | FK -> [Concept](Concept.md).ID | `authorisation_type_concept_id` |
+| `MEDICATION_NAME` | `VARCHAR` | medication name. | | -- |
+| `MEDICATION_STATEMENT_SOURCE_CONCEPT_ID` | `UUID` | medication statement source concept id. | FK -> [Concept](Concept.md).ID | `non_core_concept_id` |
+| `BNF_REFERENCE` | `VARCHAR` | bnf reference. | | `bnf_reference` |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | | -- |
+| `ISSUE_METHOD` | `VARCHAR` | issue method. | | `issue_method` |
+| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | | `date_recorded` |
+| `IS_ACTIVE` | `BOOLEAN` | is active. | | -- |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | | -- |
+| `EXPIRY_DATE` | `DATE` | expiry date. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 1. See the [schema notes section on publisher, provider, author organisation definitions](_schema_notes.md#provider-author-publisher-organisation-id)
 

--- a/OLIDS/Documentation/Schema/Observation.md
+++ b/OLIDS/Documentation/Schema/Observation.md
@@ -23,40 +23,40 @@ Uses for the Observation resource include:
 <sup>1</sup>_The boundaries between clinical findings and disorders remain a challenge in medical ontology._
 
 ## Columns
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID |
-| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `PARENT_OBSERVATION_ID` | `UUID` | parent observation id. | FK --> [Observation](Observation.md).ID |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK --> [Concept](Concept.md).ID |
-| `RESULT_VALUE` | `FLOAT` | result value. | |
-| `RESULT_VALUE_UNITS_SOURCE_CONCEPT_ID` | `UUID` | result value unit concept id. | FK --> [Concept](Concept.md).ID |
-| `RESULT_DATE` | `DATE` | result date. | |
-| `RESULT_TEXT` | `VARCHAR` | result text. | |
-| `IS_PROBLEM` | `BOOLEAN` | is problem. | |
-| `IS_REVIEW` | `BOOLEAN` | is review. | |
-| `PROBLEM_END_DATE` | `DATE` | problem end date. | |
-| `OBSERVATION_SOURCE_CONCEPT_ID` | `UUID` | observation source concept id. | FK --> [Concept](Concept.md).ID |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event.<sup>2</sup> | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date.<sup>2</sup> | |
-| `EPISODICITY_SOURCE_CONCEPT_ID` | `UUID` | episodicity concept id. | FK --> [Concept](Concept.md).ID |
-| `IS_PRIMARY` | `BOOLEAN` | is primary. | |
-| `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | |
-| `IS_PROBLEM_DELETED` | `BOOLEAN` | is problem deleted. | |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | `organization_id` |
+| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | `encounter_id` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `PARENT_OBSERVATION_ID` | `UUID` | parent observation id. | FK --> [Observation](Observation.md).ID | `parent_observation_id` |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK --> [Concept](Concept.md).ID | `date_precision_concept_id` |
+| `RESULT_VALUE` | `FLOAT` | result value. | | `result_value` |
+| `RESULT_VALUE_UNITS_SOURCE_CONCEPT_ID` | `UUID` | result value unit concept id. | FK --> [Concept](Concept.md).ID | `result_value_units_concept_id` |
+| `RESULT_DATE` | `DATE` | result date. | | `result_date` |
+| `RESULT_TEXT` | `VARCHAR` | result text. | | `result_text` |
+| `IS_PROBLEM` | `BOOLEAN` | is problem. | | `is_problem` |
+| `IS_REVIEW` | `BOOLEAN` | is review. | | `is_review` |
+| `PROBLEM_END_DATE` | `DATE` | problem end date. | | `problem_end_date` |
+| `OBSERVATION_SOURCE_CONCEPT_ID` | `UUID` | observation source concept id. | FK --> [Concept](Concept.md).ID | `non_core_concept_id` |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event.<sup>2</sup> | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date.<sup>2</sup> | | `age_at_event_neonate` |
+| `EPISODICITY_SOURCE_CONCEPT_ID` | `UUID` | episodicity concept id. | FK --> [Concept](Concept.md).ID | `episodicity_concept_id` |
+| `IS_PRIMARY` | `BOOLEAN` | is primary. | | `is_primary` |
+| `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | | `date_recorded` |
+| `IS_PROBLEM_DELETED` | `BOOLEAN` | is problem deleted. | | -- |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 1. See the [schema notes section on publisher, provider, author organisation definitions](_schema_notes.md#provider-author-publisher-organisation-id)
 1. Baby and Neonatal ages are null where patient age is byeond scope (older than) upper limit.

--- a/OLIDS/Documentation/Schema/Observation.md
+++ b/OLIDS/Documentation/Schema/Observation.md
@@ -38,7 +38,7 @@ Uses for the Observation resource include:
 | `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
 | `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK --> [Concept](Concept.md).ID | `date_precision_concept_id` |
 | `RESULT_VALUE` | `FLOAT` | result value. | | `result_value` |
-| `RESULT_VALUE_UNITS_SOURCE_CONCEPT_ID` | `UUID` | result value unit concept id. | FK --> [Concept](Concept.md).ID | `result_value_units_concept_id` |
+| `RESULT_VALUE_UNITS_SOURCE_CONCEPT_ID` | `UUID` | result value unit concept id. | FK --> [Concept](Concept.md).ID | `result_value_units` |
 | `RESULT_DATE` | `DATE` | result date. | | `result_date` |
 | `RESULT_TEXT` | `VARCHAR` | result text. | | `result_text` |
 | `IS_PROBLEM` | `BOOLEAN` | is problem. | | `is_problem` |
@@ -47,7 +47,7 @@ Uses for the Observation resource include:
 | `OBSERVATION_SOURCE_CONCEPT_ID` | `UUID` | observation source concept id. | FK --> [Concept](Concept.md).ID | `non_core_concept_id` |
 | `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | | `age_at_event` |
 | `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event.<sup>2</sup> | | -- |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date.<sup>2</sup> | | `age_at_event_neonate` |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date.<sup>2</sup> | | -- |
 | `EPISODICITY_SOURCE_CONCEPT_ID` | `UUID` | episodicity concept id. | FK --> [Concept](Concept.md).ID | `episodicity_concept_id` |
 | `IS_PRIMARY` | `BOOLEAN` | is primary. | | `is_primary` |
 | `DATE_RECORDED` | `TIMESTAMP_NTZ` | date recorded. | | `date_recorded` |

--- a/OLIDS/Documentation/Schema/Organisation.md
+++ b/OLIDS/Documentation/Schema/Organisation.md
@@ -24,23 +24,23 @@ As noted in the Event pattern, a Location represents where a service is performe
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | |
-| `ORGANISATION_CODE` | `VARCHAR` | organisation code. | |
-| `ASSIGNING_AUTHORITY_CODE` | `VARCHAR` | assigning authority code. | |
-| `NAME` | `VARCHAR` | name. | |
-| `PRIMARY_LOCATION_TYPE_SOURCE_CONCEPT_ID` | `UUID` | type code. | FK --> [Concept](Concept.md).CONCEPT_ID |
-| `TYPE_DESCRIPTION` | `VARCHAR` | type desc. | |
-| `POSTCODE` | `VARCHAR` | postcode. | |
-| `PARENT_ORGANISATION_ID` | `UUID` | parent organisation id. | FK --> [Organisation](Organisation.md).ID |
-| `OPEN_DATE` | `DATE` | open date. | |
-| `CLOSE_DATE` | `DATE` | close date. | |
-| `IS_OBSOLETE` | `BOOLEAN` | is obsolete. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | -- |
+| `ORGANISATION_CODE` | `VARCHAR` | organisation code. | | `ods_code` |
+| `ASSIGNING_AUTHORITY_CODE` | `VARCHAR` | assigning authority code. | | -- |
+| `NAME` | `VARCHAR` | name. | | `name` |
+| `PRIMARY_LOCATION_TYPE_SOURCE_CONCEPT_ID` | `UUID` | type code. | FK --> [Concept](Concept.md).CONCEPT_ID | `type_code` |
+| `TYPE_DESCRIPTION` | `VARCHAR` | type desc. | | `type_desc` |
+| `POSTCODE` | `VARCHAR` | postcode. | | `postcode` |
+| `PARENT_ORGANISATION_ID` | `UUID` | parent organisation id. | FK --> [Organisation](Organisation.md).ID | `parent_organization_id` |
+| `OPEN_DATE` | `DATE` | open date. | | -- |
+| `CLOSE_DATE` | `DATE` | close date. | | -- |
+| `IS_OBSOLETE` | `BOOLEAN` | is obsolete. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Patient.md
+++ b/OLIDS/Documentation/Schema/Patient.md
@@ -50,9 +50,9 @@ The data in the Resource covers the "who" information about the patient: its att
 | `LAST_NAME` | `VARCHAR` | last name. | | ❌ column removed | `last_name` |
 | `GENDER_SOURCE_CONCEPT_ID` | `Unknown` | gender concept id. | FK -> [Concept](Concept.md).ID | | -- |
 | `BIRTH_DATE` | `DATE` | birth date. | | 📅 date generalised | `date_of_birth` |
-| `BIRTH_YEAR` | `BIGINT` | birth year. | | | `birth_year` |
-| `BIRTH_MONTH` | `BIGINT` | birth month. | | | `birth_month` |
-| `BIRTH_WEEK_ISO` | `BIGINT` | birth week iso. | | | `birth_week` |
+| `BIRTH_YEAR` | `BIGINT` | birth year. | | | -- |
+| `BIRTH_MONTH` | `BIGINT` | birth month. | | | -- |
+| `BIRTH_WEEK_ISO` | `BIGINT` | birth week iso. | | | -- |
 | `BIRTH_DAY` | `BIGINT` | birth day. | | ❌ column removed | -- |
 | `DEATH_DATE` | `DATE` | death date. | | 📅 date generalised | `date_of_death` |
 | `DEATH_YEAR` | `BIGINT` | death year. | | | -- |

--- a/OLIDS/Documentation/Schema/Patient.md
+++ b/OLIDS/Documentation/Schema/Patient.md
@@ -31,41 +31,41 @@ The data in the Resource covers the "who" information about the patient: its att
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK | Masking policy |
-| --- | --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | |
-| `PERSON_ID` | `UUID` | linked person id. | FK -> [Person](Person.md).ID | |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | |
-| `REGISTERED_PRACTICE_ORGANISATION_ID` | `UUID` | registered practice id. | FK -> [Organisation](Organisation.md).ID | |
-| `DATE_OF_REGISTRATION` | `DATE` | date of registration. | | |
-| `DATE_OF_DEACTIVATION` | `DATE` | date of deactivation. | | |
-| `NHS_NUMBER` | `VARCHAR` | nhs number. | | ❌ column removed |
-| `SK_PATIENT_ID` | `NUMBER` | sk patient id. | | ℹ️ pseudo view only |
-| `TITLE` | `VARCHAR` | title. | | |
-| `FIRST_NAME` | `VARCHAR` | first name. | | ❌ column removed |
-| `MIDDLE_NAME` | `VARCHAR` | middle name. | | ❌ column removed |
-| `LAST_NAME` | `VARCHAR` | last name. | | ❌ column removed |
-| `GENDER_SOURCE_CONCEPT_ID` | `Unknown` | gender concept id. | FK -> [Concept](Concept.md).ID | |
-| `BIRTH_DATE` | `DATE` | birth date. | | 📅 date generalised |
-| `BIRTH_YEAR` | `BIGINT` | birth year. | | |
-| `BIRTH_MONTH` | `BIGINT` | birth month. | | |
-| `BIRTH_WEEK_ISO` | `BIGINT` | birth week iso. | | |
-| `BIRTH_DAY` | `BIGINT` | birth day. | | ❌ column removed |
-| `DEATH_DATE` | `DATE` | death date. | | 📅 date generalised |
-| `DEATH_YEAR` | `BIGINT` | death year. | | |
-| `DEATH_MONTH` | `BIGINT` | death month. | | |
-| `DEATH_WEEK_ISO` | `BIGINT` | death week iso. | | |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | | |
-| `IS_TEST_PATIENT` | `Unknown` | is test patient. | | |
-| `IS_SPINE_SENSITIVE` | `BOOLEAN` | is spine sensitive. | | |
-| `LDS_SOURCE_DATASET` | `VARCHAR` | name of the source dataset | | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the  |data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | |
+| Column Name | Data Type (Size) | Description | PK/FK | Masking policy | Compass Equivalent |
+| --- | --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | | -- |
+| `PERSON_ID` | `UUID` | linked person id. | FK -> [Person](Person.md).ID | | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | | -- |
+| `REGISTERED_PRACTICE_ORGANISATION_ID` | `UUID` | registered practice id. | FK -> [Organisation](Organisation.md).ID | | -- |
+| `DATE_OF_REGISTRATION` | `DATE` | date of registration. | | | -- |
+| `DATE_OF_DEACTIVATION` | `DATE` | date of deactivation. | | | -- |
+| `NHS_NUMBER` | `VARCHAR` | nhs number. | | ❌ column removed | `nhs_number` |
+| `SK_PATIENT_ID` | `NUMBER` | sk patient id. | | ℹ️ pseudo view only | -- |
+| `TITLE` | `VARCHAR` | title. | | | `title` |
+| `FIRST_NAME` | `VARCHAR` | first name. | | ❌ column removed | `first_names` |
+| `MIDDLE_NAME` | `VARCHAR` | middle name. | | ❌ column removed | -- |
+| `LAST_NAME` | `VARCHAR` | last name. | | ❌ column removed | `last_name` |
+| `GENDER_SOURCE_CONCEPT_ID` | `Unknown` | gender concept id. | FK -> [Concept](Concept.md).ID | | -- |
+| `BIRTH_DATE` | `DATE` | birth date. | | 📅 date generalised | `date_of_birth` |
+| `BIRTH_YEAR` | `BIGINT` | birth year. | | | `birth_year` |
+| `BIRTH_MONTH` | `BIGINT` | birth month. | | | `birth_month` |
+| `BIRTH_WEEK_ISO` | `BIGINT` | birth week iso. | | | `birth_week` |
+| `BIRTH_DAY` | `BIGINT` | birth day. | | ❌ column removed | -- |
+| `DEATH_DATE` | `DATE` | death date. | | 📅 date generalised | `date_of_death` |
+| `DEATH_YEAR` | `BIGINT` | death year. | | | -- |
+| `DEATH_MONTH` | `BIGINT` | death month. | | | -- |
+| `DEATH_WEEK_ISO` | `BIGINT` | death week iso. | | | -- |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | | | -- |
+| `IS_TEST_PATIENT` | `Unknown` | is test patient. | | | -- |
+| `IS_SPINE_SENSITIVE` | `BOOLEAN` | is spine sensitive. | | | -- |
+| `LDS_SOURCE_DATASET` | `VARCHAR` | name of the source dataset | | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the  |data. | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | | -- |
 
 1. See the [schema notes section on publisher, provider, author organisation definitions](_schema_notes.md#provider-author-publisher-organisation-id)
 

--- a/OLIDS/Documentation/Schema/Patient_Address.md
+++ b/OLIDS/Documentation/Schema/Patient_Address.md
@@ -17,29 +17,29 @@ Patient addresses with different uses or applicable periods.
 
 ### pseudo view
 
-| Column Name | Data Type (Size) | Description | PK/FK | Masking Policy |
-| --- | --- | --- | --- | --- |
-| `ID` | `UUID` | id. | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID | |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider^1^. | FK -> [Organisation](Organisation.md).ID | |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID | |
-| `IS_HOME_ADDRESS` | `BOOLEAN` | is home address. | | |
-| `ADDRESS_TYPE_SOURCE_CONCEPT_ID` | `UUID` | address type source concept id. | FK -> [Concept](Concept.md).ID | |
-| `ADDRESS_LINE_1` | `VARCHAR` | address line 1. | | ❌column removed |
-| `ADDRESS_LINE_2` | `VARCHAR` | address line 2. | | ❌column removed |
-| `ADDRESS_LINE_3` | `VARCHAR` | address line 3. | | ❌column removed |
-| `ADDRESS_LINE_4` | `VARCHAR` | address line 4. | | ❌column removed |
-| `CITY` | `VARCHAR` | city. | | ❌column removed |
-| `POSTCODE` | `VARCHAR` | patient address postcode. | | #️⃣hashed |
-| `START_DATE` | `DATE` | start date. | | |
-| `END_DATE` | `DATE` | end date. | | |
-| `LDS_IS_DELETED` | `BOOLEAN` | True if the record has been marked as deleted. | | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | ODS code of the organisation who, acting as the data controller, permitted the release of data. | | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | Timestamp extracted from source file name indicating extraction time. | | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP` WITH TIME ZONE | lds transform date time. | | |
+| Column Name | Data Type (Size) | Description | PK/FK | Masking Policy | Compass Equivalent |
+| --- | --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | | | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID | | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider^1^. | FK -> [Organisation](Organisation.md).ID | | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID | | `organization_id` |
+| `IS_HOME_ADDRESS` | `BOOLEAN` | is home address. | | | -- |
+| `ADDRESS_TYPE_SOURCE_CONCEPT_ID` | `UUID` | address type source concept id. | FK -> [Concept](Concept.md).ID | | `use_concept_id` |
+| `ADDRESS_LINE_1` | `VARCHAR` | address line 1. | | ❌column removed | `address_line_1` |
+| `ADDRESS_LINE_2` | `VARCHAR` | address line 2. | | ❌column removed | `address_line_2` |
+| `ADDRESS_LINE_3` | `VARCHAR` | address line 3. | | ❌column removed | `address_line_3` |
+| `ADDRESS_LINE_4` | `VARCHAR` | address line 4. | | ❌column removed | `address_line_4` |
+| `CITY` | `VARCHAR` | city. | | ❌column removed | `city` |
+| `POSTCODE` | `VARCHAR` | patient address postcode. | | #️⃣hashed | `postcode` |
+| `START_DATE` | `DATE` | start date. | | | `start_date` |
+| `END_DATE` | `DATE` | end date. | | | `end_date` |
+| `LDS_IS_DELETED` | `BOOLEAN` | True if the record has been marked as deleted. | | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | ODS code of the organisation who, acting as the data controller, permitted the release of data. | | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | Timestamp extracted from source file name indicating extraction time. | | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP` WITH TIME ZONE | lds transform date time. | | | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Patient_Contact.md
+++ b/OLIDS/Documentation/Schema/Patient_Contact.md
@@ -14,23 +14,23 @@ A Patient may have multiple ways to be contacted with different uses or applicab
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK | Masking policy |
-| --- | --- | --- | --- | --- |
-| `ID` | `UUID` | id. | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | | |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id publisher. | | |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id provider. | | |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id author. | | |
-| `CONTACT_TYPE_SOURCE_CONCEPT_ID` | `UUID` | contact type concept id. | FK -> [Concept](Concept.md).ID | |
-| `VALUE` | `VARCHAR` | value. | available in PID views only | ❌ column removed |
-| `START_DATE` | `DATE` | start date. | | |
-| `END_DATE` | `DATE` | end date. | | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | |
+| Column Name | Data Type (Size) | Description | PK/FK | Masking policy | Compass Equivalent |
+| --- | --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | | | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | | | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id publisher. | | | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id provider. | | | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id author. | | | `organization_id` |
+| `CONTACT_TYPE_SOURCE_CONCEPT_ID` | `UUID` | contact type concept id. | FK -> [Concept](Concept.md).ID | | `type_concept_id` |
+| `VALUE` | `VARCHAR` | value. | available in PID views only | ❌ column removed | `value` |
+| `START_DATE` | `DATE` | start date. | | | `start_date` |
+| `END_DATE` | `DATE` | end date. | | | `end_date` |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | | | `organization_id` |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Patient_Person.md
+++ b/OLIDS/Documentation/Schema/Patient_Person.md
@@ -14,17 +14,17 @@
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK | Masking policy |
-| --- | --- | --- | --- | --- |
-| `ID` | `UUID` | Business key for the patient-person link. Carries the patient's LDS_BUSINESS_ID (derived from PATIENTGUID and ORGANISATIONGUID) so that downstream consumers can join back to Patient. tests: - unique - not_null | PK | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Record-level identifier for the patient, inherited from Admin_Patient_Sequenced. Derived from PATIENTGUID, ORGANISATIONGUID, file row number, and file name. | | |
-| `PATIENT_ID` | `UUID` | Foreign key to Patient. Equals the patient's LDS_BUSINESS_ID (same value as ID). | FK -> [Patient](Patient.md).ID | |
-| `PERSON_ID` | `UUID` | Foreign key to Person. The ID of the matched person record from the INNER JOIN. | FK -> [Person](Person.md).ID | |
-| `LDS_BUSINESS_ID_PERSON` | `UUID` | Business key of the linked person record. Derived via generate_person_business_id using the patient's NHS_NUMBER, LDS_BUSINESS_ID, and LDS_SOURCE_RECORD_ID - matching the logic used to generate ID in Person. | | |
-| `LDS_SOURCE_RECORD_ID_PERSON` | `UUID` | Record-level identifier of the linked person record, sourced from Person. Retained separately from LDS_SOURCE_RECORD_ID to distinguish the person record identifier from the patient record identifier in this link table. | | |
-| `GP_PRACTICE_CODE` | `VARCHAR` | ODS code of the patient's registered GP practice, sourced from Person. 'Unknown' when the organisation could not be resolved. | | |
-| `LDS_IS_DELETED` | `BOOLEAN` | Indicates whether the source patient record has been logically deleted. Coalesced to FALSE when the source value is NULL. | | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | |
+| Column Name | Data Type (Size) | Description | PK/FK | Masking policy | Compass Equivalent |
+| --- | --- | --- | --- | --- | --- |
+| `ID` | `UUID` | Business key for the patient-person link. Carries the patient's LDS_BUSINESS_ID (derived from PATIENTGUID and ORGANISATIONGUID) so that downstream consumers can join back to Patient. tests: - unique - not_null | PK | | -- |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Record-level identifier for the patient, inherited from Admin_Patient_Sequenced. Derived from PATIENTGUID, ORGANISATIONGUID, file row number, and file name. | | | -- |
+| `PATIENT_ID` | `UUID` | Foreign key to Patient. Equals the patient's LDS_BUSINESS_ID (same value as ID). | FK -> [Patient](Patient.md).ID | | `patient_id` |
+| `PERSON_ID` | `UUID` | Foreign key to Person. The ID of the matched person record from the INNER JOIN. | FK -> [Person](Person.md).ID | | `person_id` |
+| `LDS_BUSINESS_ID_PERSON` | `UUID` | Business key of the linked person record. Derived via generate_person_business_id using the patient's NHS_NUMBER, LDS_BUSINESS_ID, and LDS_SOURCE_RECORD_ID - matching the logic used to generate ID in Person. | | | -- |
+| `LDS_SOURCE_RECORD_ID_PERSON` | `UUID` | Record-level identifier of the linked person record, sourced from Person. Retained separately from LDS_SOURCE_RECORD_ID to distinguish the person record identifier from the patient record identifier in this link table. | | | -- |
+| `GP_PRACTICE_CODE` | `VARCHAR` | ODS code of the patient's registered GP practice, sourced from Person. 'Unknown' when the organisation could not be resolved. | | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | Indicates whether the source patient record has been logically deleted. Coalesced to FALSE when the source value is NULL. | | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Person.md
+++ b/OLIDS/Documentation/Schema/Person.md
@@ -16,53 +16,53 @@ PDS responses will always be used over an source system stub where both exist fo
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK | Masking Policy |
-| --- | --- | --- | --- | --- |
-| `ID` | `UUID` | unique identifier for the person. | PK | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique source record identifier (generated deterministcally from source data) | | |
-| `REQ_NHS_NUMBER` | `VARCHAR` | The NHS number that was sent in the PDS request (PDS rows) or the NHS number held on the EMIS Admin_Patient record (EMIS stub rows). Hashed at source. | | #️⃣ hashed |
-| `MATCHED_NHS_NO` | `VARCHAR` | The NHS number returned by PDS as the verified match. For EMIS stub rows this is set equal to REQ_NHS_NUMBER. Hashed at source. | | #️⃣ hashed |
-| `FAMILY_NAME` | `VARCHAR` | Patient's family / last name. Sourced from PDS FAMILY_NAME (PDS rows) or EMIS SURNAME (EMIS stub rows). | | ❌ column removed |
-| `GIVEN_NAME` | `VARCHAR` | Patient's first given name. | | ❌ column removed |
-| `OTHER_GIVEN_NAME` | `VARCHAR` | Additional given names. Sourced from PDS OTHER_GIVEN_NAME or EMIS MIDDLE_NAMES. | | ❌ column removed |
-| `GENDER` | `VARCHAR` | Administrative gender. Populated from PDS response. NULL for EMIS stub rows as EMIS does not supply a gender field in the same format. | | |
-| `DATE_OF_BIRTH` | `VARCHAR` | Patient's date of birth. | | 📅 truncated to 1st of month |
-| `DATE_OF_BIRTH_YEAR` | `BIGINT` | Year component of DATE_OF_BIRTH. | | |
-| `DATE_OF_BIRTH_MONTH` | `BIGINT` | Month component of DATE_OF_BIRTH. | | |
-| `DATE_OF_BIRTH_DAY` | `BIGINT` | Day component of DATE_OF_BIRTH. | | ❌ column removed |
-| `DATE_OF_BIRTH_TIME` | `TIME` | Time component of DATE_OF_BIRTH. Always NULL — neither PDS nor EMIS provides a time-of-birth value. | | ❌ column removed |
-| `DATE_OF_DEATH` | `VARCHAR` | Patient's date of death. NULL if the patient is living. | | 📅 truncated to 1st of month |
-| `DATE_OF_DEATH_YEAR` | `BIGINT` | Year component of DATE_OF_DEATH. | | |
-| `DATE_OF_DEATH_MONTH` | `BIGINT` | Month component of DATE_OF_DEATH. | | |
-| `DATE_OF_DEATH_DAY` | `BIGINT` | Day component of DATE_OF_DEATH. | | ❌ column removed |
-| `DATE_OF_DEATH_TIME` | `TIME` | Time component of DATE_OF_DEATH. Always NULL — neither PDS nor EMIS provides a time-of-death value. | | ❌ column removed |
-| `DEATH_NOTIFICATION_STATUS` | `VARCHAR` | PDS death notification status code. NULL for EMIS stub rows. | | |
-| `ADDRESS_LINE1` | `VARCHAR` | First line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed |
-| `ADDRESS_LINE2` | `VARCHAR` | Second line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed |
-| `ADDRESS_LINE3` | `VARCHAR` | Third line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed |
-| `ADDRESS_LINE4` | `VARCHAR` | Fourth line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed |
-| `ADDRESS_LINE5` | `VARCHAR` | Fifth line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed |
-| `POSTCODE` | `VARCHAR` | Patient's postcode. NULL for EMIS stub rows. | | #️⃣ hashed |
-| `PREFERRED_CONTACT_METHOD` | `VARCHAR` | PDS preferred contact method code. NULL for EMIS stub rows. | | |
-| `NOMINATED_PHARMACY` | `VARCHAR` | PDS nominated pharmacy ODS code. NULL for EMIS stub rows. | | |
-| `DISPENSING_DOCTOR` | `VARCHAR` | PDS dispensing doctor code. NULL for EMIS stub rows. | | |
-| `MEDICAL_APPLIANCE_SUPPLIER` | `VARCHAR` | PDS medical appliance supplier code. NULL for EMIS stub rows. | | |
-| `GP_PRACTICE_CODE` | `VARCHAR` | ODS code of the patient's registered GP practice. For PDS rows this comes directly from the PDS response. For EMIS stub rows it is resolved from Organisation via the patient's LDS_BUSINESS_ID_ORGANISATION; defaults to 'Unknown' when no match is found. | | |
-| `GP_REGISTRATION_DATE` | `VARCHAR` | Date the patient registered with their current GP practice. Populated for PDS rows only; NULL for EMIS stub rows. | | |
-| `NHAIS_POSTING_ID` | `VARCHAR` | PDS NHAIS posting identifier. NULL for EMIS stub rows. | | |
-| `AS_AT_DATE` | `VARCHAR` | The date the PDS record was valid as at. NULL for EMIS stub rows. | | |
-| `LOCAL_PATIENT_ID` | `VARCHAR` | Local patient identifier from the PDS response. NULL for EMIS stub rows. | | |
-| `INTERNAL_ID` | `VARCHAR` | PDS internal identifier. NULL for EMIS stub rows. | | |
-| `TELEPHONE_NUMBER` | `VARCHAR` | Patient's telephone number from PDS. NULL for EMIS stub rows. | | ❌ column removed |
-| `MOBILE_NUMBER` | `VARCHAR` | Patient's mobile number from PDS. NULL for EMIS stub rows. | | ❌ column removed |
-| `EMAIL_ADDRESS` | `VARCHAR` | Patient's email address from PDS. NULL for EMIS stub rows. | | ❌ column removed |
-| `MPS_ID` | `VARCHAR` | Master Patient Service identifier from PDS. NULL for EMIS stub rows. | | |
-| `SENSITIVITY_FLAG` | `VARCHAR` | Always NULL in this model. The source SENSITIVITY_FLAG from PDS is intentionally overridden with CAST(NULL AS VARCHAR(1)) to prevent accidental disclosure of sensitive flagging in downstream consumers. | | |
-| `ERROR_SUCCESS_CODE` | `VARCHAR` | PDS response error_success code (sourced from the ERROR_SUCCESS_CODE column in PDS_DATA_MASKED). For EMIS stub rows, set to '92' when SPINE_SENSITIVE is TRUE; otherwise NULL. | | |
-| `LDS_IS_DELETED` | `BOOLEAN` | Indicates whether the source record has been logically deleted. Always FALSE for PDS rows (the PDS source has no deleted column). Inherited from the Admin_Patient source for EMIS stub rows. | | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | The timestamp when the source record was acquired or supplied to LDS | | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP` | The timestamp when the source record was transformed by LDS | | |
-| `Source` | `VARCHAR` | Indicates the origin of the person record. 'Person' for records sourced from PDS (Person_Sequenced); 'EMIS' for stub records sourced from Admin_Patient_Sequenced where no PDS response exists. | | |
+| Column Name | Data Type (Size) | Description | PK/FK | Masking Policy | Compass Equivalent |
+| --- | --- | --- | --- | --- | --- |
+| `ID` | `UUID` | unique identifier for the person. | PK | | -- |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique source record identifier (generated deterministcally from source data) | | | -- |
+| `REQ_NHS_NUMBER` | `VARCHAR` | The NHS number that was sent in the PDS request (PDS rows) or the NHS number held on the EMIS Admin_Patient record (EMIS stub rows). Hashed at source. | | #️⃣ hashed | -- |
+| `MATCHED_NHS_NO` | `VARCHAR` | The NHS number returned by PDS as the verified match. For EMIS stub rows this is set equal to REQ_NHS_NUMBER. Hashed at source. | | #️⃣ hashed | -- |
+| `FAMILY_NAME` | `VARCHAR` | Patient's family / last name. Sourced from PDS FAMILY_NAME (PDS rows) or EMIS SURNAME (EMIS stub rows). | | ❌ column removed | -- |
+| `GIVEN_NAME` | `VARCHAR` | Patient's first given name. | | ❌ column removed | -- |
+| `OTHER_GIVEN_NAME` | `VARCHAR` | Additional given names. Sourced from PDS OTHER_GIVEN_NAME or EMIS MIDDLE_NAMES. | | ❌ column removed | -- |
+| `GENDER` | `VARCHAR` | Administrative gender. Populated from PDS response. NULL for EMIS stub rows as EMIS does not supply a gender field in the same format. | | | -- |
+| `DATE_OF_BIRTH` | `VARCHAR` | Patient's date of birth. | | 📅 truncated to 1st of month | -- |
+| `DATE_OF_BIRTH_YEAR` | `BIGINT` | Year component of DATE_OF_BIRTH. | | | `birth_year` |
+| `DATE_OF_BIRTH_MONTH` | `BIGINT` | Month component of DATE_OF_BIRTH. | | | `birth_month` |
+| `DATE_OF_BIRTH_DAY` | `BIGINT` | Day component of DATE_OF_BIRTH. | | ❌ column removed | -- |
+| `DATE_OF_BIRTH_TIME` | `TIME` | Time component of DATE_OF_BIRTH. Always NULL — neither PDS nor EMIS provides a time-of-birth value. | | ❌ column removed | -- |
+| `DATE_OF_DEATH` | `VARCHAR` | Patient's date of death. NULL if the patient is living. | | 📅 truncated to 1st of month | -- |
+| `DATE_OF_DEATH_YEAR` | `BIGINT` | Year component of DATE_OF_DEATH. | | | -- |
+| `DATE_OF_DEATH_MONTH` | `BIGINT` | Month component of DATE_OF_DEATH. | | | -- |
+| `DATE_OF_DEATH_DAY` | `BIGINT` | Day component of DATE_OF_DEATH. | | ❌ column removed | -- |
+| `DATE_OF_DEATH_TIME` | `TIME` | Time component of DATE_OF_DEATH. Always NULL — neither PDS nor EMIS provides a time-of-death value. | | ❌ column removed | -- |
+| `DEATH_NOTIFICATION_STATUS` | `VARCHAR` | PDS death notification status code. NULL for EMIS stub rows. | | | -- |
+| `ADDRESS_LINE1` | `VARCHAR` | First line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `ADDRESS_LINE2` | `VARCHAR` | Second line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `ADDRESS_LINE3` | `VARCHAR` | Third line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `ADDRESS_LINE4` | `VARCHAR` | Fourth line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `ADDRESS_LINE5` | `VARCHAR` | Fifth line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `POSTCODE` | `VARCHAR` | Patient's postcode. NULL for EMIS stub rows. | | #️⃣ hashed | -- |
+| `PREFERRED_CONTACT_METHOD` | `VARCHAR` | PDS preferred contact method code. NULL for EMIS stub rows. | | | -- |
+| `NOMINATED_PHARMACY` | `VARCHAR` | PDS nominated pharmacy ODS code. NULL for EMIS stub rows. | | | -- |
+| `DISPENSING_DOCTOR` | `VARCHAR` | PDS dispensing doctor code. NULL for EMIS stub rows. | | | -- |
+| `MEDICAL_APPLIANCE_SUPPLIER` | `VARCHAR` | PDS medical appliance supplier code. NULL for EMIS stub rows. | | | -- |
+| `GP_PRACTICE_CODE` | `VARCHAR` | ODS code of the patient's registered GP practice. For PDS rows this comes directly from the PDS response. For EMIS stub rows it is resolved from Organisation via the patient's LDS_BUSINESS_ID_ORGANISATION; defaults to 'Unknown' when no match is found. | | | -- |
+| `GP_REGISTRATION_DATE` | `VARCHAR` | Date the patient registered with their current GP practice. Populated for PDS rows only; NULL for EMIS stub rows. | | | -- |
+| `NHAIS_POSTING_ID` | `VARCHAR` | PDS NHAIS posting identifier. NULL for EMIS stub rows. | | | -- |
+| `AS_AT_DATE` | `VARCHAR` | The date the PDS record was valid as at. NULL for EMIS stub rows. | | | -- |
+| `LOCAL_PATIENT_ID` | `VARCHAR` | Local patient identifier from the PDS response. NULL for EMIS stub rows. | | | -- |
+| `INTERNAL_ID` | `VARCHAR` | PDS internal identifier. NULL for EMIS stub rows. | | | -- |
+| `TELEPHONE_NUMBER` | `VARCHAR` | Patient's telephone number from PDS. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `MOBILE_NUMBER` | `VARCHAR` | Patient's mobile number from PDS. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `EMAIL_ADDRESS` | `VARCHAR` | Patient's email address from PDS. NULL for EMIS stub rows. | | ❌ column removed | -- |
+| `MPS_ID` | `VARCHAR` | Master Patient Service identifier from PDS. NULL for EMIS stub rows. | | | -- |
+| `SENSITIVITY_FLAG` | `VARCHAR` | Always NULL in this model. The source SENSITIVITY_FLAG from PDS is intentionally overridden with CAST(NULL AS VARCHAR(1)) to prevent accidental disclosure of sensitive flagging in downstream consumers. | | | -- |
+| `ERROR_SUCCESS_CODE` | `VARCHAR` | PDS response error_success code (sourced from the ERROR_SUCCESS_CODE column in PDS_DATA_MASKED). For EMIS stub rows, set to '92' when SPINE_SENSITIVE is TRUE; otherwise NULL. | | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | Indicates whether the source record has been logically deleted. Always FALSE for PDS rows (the PDS source has no deleted column). Inherited from the Admin_Patient source for EMIS stub rows. | | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | The timestamp when the source record was acquired or supplied to LDS | | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP` | The timestamp when the source record was transformed by LDS | | | -- |
+| `Source` | `VARCHAR` | Indicates the origin of the person record. 'Person' for records sourced from PDS (Person_Sequenced); 'EMIS' for stub records sourced from Admin_Patient_Sequenced where no PDS response exists. | | | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Person.md
+++ b/OLIDS/Documentation/Schema/Person.md
@@ -27,8 +27,8 @@ PDS responses will always be used over an source system stub where both exist fo
 | `OTHER_GIVEN_NAME` | `VARCHAR` | Additional given names. Sourced from PDS OTHER_GIVEN_NAME or EMIS MIDDLE_NAMES. | | ❌ column removed | -- |
 | `GENDER` | `VARCHAR` | Administrative gender. Populated from PDS response. NULL for EMIS stub rows as EMIS does not supply a gender field in the same format. | | | -- |
 | `DATE_OF_BIRTH` | `VARCHAR` | Patient's date of birth. | | 📅 truncated to 1st of month | -- |
-| `DATE_OF_BIRTH_YEAR` | `BIGINT` | Year component of DATE_OF_BIRTH. | | | `birth_year` |
-| `DATE_OF_BIRTH_MONTH` | `BIGINT` | Month component of DATE_OF_BIRTH. | | | `birth_month` |
+| `DATE_OF_BIRTH_YEAR` | `BIGINT` | Year component of DATE_OF_BIRTH. | | | -- |
+| `DATE_OF_BIRTH_MONTH` | `BIGINT` | Month component of DATE_OF_BIRTH. | | | -- |
 | `DATE_OF_BIRTH_DAY` | `BIGINT` | Day component of DATE_OF_BIRTH. | | ❌ column removed | -- |
 | `DATE_OF_BIRTH_TIME` | `TIME` | Time component of DATE_OF_BIRTH. Always NULL — neither PDS nor EMIS provides a time-of-birth value. | | ❌ column removed | -- |
 | `DATE_OF_DEATH` | `VARCHAR` | Patient's date of death. NULL if the patient is living. | | 📅 truncated to 1st of month | -- |

--- a/OLIDS/Documentation/Schema/Practitioner.md
+++ b/OLIDS/Documentation/Schema/Practitioner.md
@@ -38,22 +38,22 @@ The Practitioner resource is used for anyone involved in the provision of care o
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID |
-| `GMC_CODE` | `VARCHAR` | general medical council code | - |
-| `TITLE` | `VARCHAR` | practitioners title. | - |
-| `FIRST_NAME` | `VARCHAR` | practitioners first/given name. | - |
-| `SURNAME` | `VARCHAR` | practitioners surname. | - |
-| `NAME` | `VARCHAR` | practitioners full name. | - |
-| `IS_OBSOLETE` | `BOOLEAN` | is practitioner record obsolete. | - |
-| `LDS_IS_DELETED` | `BOOLEAN` | is the practitioner record deleted in the source system. | - |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The ODS<sup>1<\sup> code of the organisation (data controller) who publishes the data. | - |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | - |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | the timestamp when the transform process that generated this record. | - |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - | -- |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID | -- |
+| `GMC_CODE` | `VARCHAR` | general medical council code | - | `gmc_code` |
+| `TITLE` | `VARCHAR` | practitioners title. | - | -- |
+| `FIRST_NAME` | `VARCHAR` | practitioners first/given name. | - | `name` |
+| `SURNAME` | `VARCHAR` | practitioners surname. | - | `name` |
+| `NAME` | `VARCHAR` | practitioners full name. | - | -- |
+| `IS_OBSOLETE` | `BOOLEAN` | is practitioner record obsolete. | - | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | is the practitioner record deleted in the source system. | - | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The ODS<sup>1<\sup> code of the organisation (data controller) who publishes the data. | - | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | - | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | the timestamp when the transform process that generated this record. | - | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Practitioner_In_Role.md
+++ b/OLIDS/Documentation/Schema/Practitioner_In_Role.md
@@ -36,22 +36,22 @@ For use cases where an organisation has activities where a practitioner is not d
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `VARCHAR` | id. | |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `EMPLOYER_ORGANISATION_ID` | `UUID` | organisation id of the employing organisation for this record. | FK -> [Organisation](Organisation.md).ID |
-| `ROLE_CODE` | `VARCHAR` | role code. | |
-| `ROLE` | `VARCHAR` | role. | |
-| `DATE_EMPLOYMENT_START` | `DATE` | date employment start. | |
-| `DATE_EMPLOYMENT_END` | `DATE` | date employment end. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | True if the record has been marked as deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | ODS code of the owning organisation for this record. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | Timestamp extracted from source file name indicating extraction time. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `VARCHAR` | id. | | -- |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. | | -- |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | -- |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | -- |
+| `EMPLOYER_ORGANISATION_ID` | `UUID` | organisation id of the employing organisation for this record. | FK -> [Organisation](Organisation.md).ID | -- |
+| `ROLE_CODE` | `VARCHAR` | role code. | | -- |
+| `ROLE` | `VARCHAR` | role. | | -- |
+| `DATE_EMPLOYMENT_START` | `DATE` | date employment start. | | -- |
+| `DATE_EMPLOYMENT_END` | `DATE` | date employment end. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | True if the record has been marked as deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | ODS code of the owning organisation for this record. | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | Timestamp extracted from source file name indicating extraction time. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Procedure_Request.md
+++ b/OLIDS/Documentation/Schema/Procedure_Request.md
@@ -25,30 +25,30 @@ The ProcedureRequest resource allows requesting only a single procedure. If a wo
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisation id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisation id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | - |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | [Concept](Concept.md).CONCEPT_ID |
-| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | - |
-| `DESCRIPTION` | `VARCHAR` | description. | - |
-| `PROCEDURE_REQUEST_SOURCE_CONCEPT_ID` | `UUID` | procedure request source concept id. | [Concept](Concept.md).CONCEPT_ID |
-| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | - |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | - |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | - |
-| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | - |
-| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | - |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | - |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | The timestamp when the record was supplied to, or acquired by, LDS. | - |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisation id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisation id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisation id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | `encounter_id` |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | - | `clinical_effective_date` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | [Concept](Concept.md).CONCEPT_ID | `date_precision_concept_id` |
+| `DATE_RECORDED` | `TIMESTAMP` | date recorded. | - | `date_recorded` |
+| `DESCRIPTION` | `VARCHAR` | description. | - | -- |
+| `PROCEDURE_REQUEST_SOURCE_CONCEPT_ID` | `UUID` | procedure request source concept id. | [Concept](Concept.md).CONCEPT_ID | `non_core_concept_id` |
+| `AGE_AT_EVENT` | `NUMBER` | patient age, in whole years, at clinical effective date of event. | - | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | patient age, in categorised groups for ages under 1 year, at clinical effective date of event. NULL where patient is over 1 years old. | - | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | patient age, in days under 27 days old, at clinical effective date. NULL where patient is over 27 days old. | - | -- |
+| `IS_CONFIDENTIAL` | `BOOLEAN` | is confidential. | - | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | standardised representation of soft-deletes. | - | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The Organisation Data Service (ODS) code of the organisation who, acting as the data controller, publishes the data. | - | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP_NTZ` | The timestamp when the record was supplied to, or acquired by, LDS. | - | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Referral_Request.md
+++ b/OLIDS/Documentation/Schema/Referral_Request.md
@@ -50,11 +50,11 @@ ReferralRequest is also intended for use when there is a complete and more perma
 | `RECIPIENT_ORGANISATION_ID` | `UUID` | recipient organisation id. | [ORANGANISATION](Organisation.md).ID | `recipient_organization_id` |
 | `REFERRAL_REQUEST_PRIORITY_SOURCE_CONCEPT_ID` | `UUID` | referral request priority concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `referral_request_priority_concept_id` |
 | `REFERRAL_REQUEST_TYPE_SOURCE_CONCEPT_ID` | `UUID` | referral request type concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `referral_request_type_concept_id` |
-| `REFERRAL_REQUEST_SPECIALTY_SOURCE_CONCEPT_ID` | `UUID` | referral request specialty concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `referral_request_specialty_concept_id` |
+| `REFERRAL_REQUEST_SPECIALTY_SOURCE_CONCEPT_ID` | `UUID` | referral request specialty concept id. | FK->[Concept](Concept.md).CONCEPT_ID | -- |
 | `MODE` | `VARCHAR` | mode. | | `mode` |
 | `IS_OUTGOING_REFERRAL` | `BOOLEAN` | is outgoing referral. | | `outgoing_referral` |
 | `IS_REVIEW` | `BOOLEAN` | is review. | | `is_review` |
-| `REFERRAL_REQUEST_SOURCE_CONCEPT_ID` | `UUID` | referral request source concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `raw_concept_id` |
+| `REFERRAL_REQUEST_SOURCE_CONCEPT_ID` | `UUID` | referral request source concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `non_core_concept_id` |
 | `AGE_AT_EVENT` | `NUMBER` | age at event. | | `age_at_event` |
 | `AGE_AT_EVENT_BABY` | `NUMBER` | age at event baby. | | -- |
 | `AGE_AT_EVENT_NEONATE` | `NUMBER` | age at event neonate. | | -- |

--- a/OLIDS/Documentation/Schema/Referral_Request.md
+++ b/OLIDS/Documentation/Schema/Referral_Request.md
@@ -32,39 +32,39 @@ ReferralRequest is also intended for use when there is a complete and more perma
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - |
-| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID |
-| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `UNIQUE_BOOKING_REFERENCE_NUMBER` | `VARCHAR` | unique booking reference number. | |
-| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | |
-| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK->[Concept](Concept.md).CONCEPT_ID |
-| `REQUESTER_ORGANISATION_ID` | `UUID` | requester organisation id. | [ORANGANISATION](Organisation.md).ID |
-| `RECIPIENT_ORGANISATION_ID` | `UUID` | recipient organisation id. | [ORANGANISATION](Organisation.md).ID |
-| `REFERRAL_REQUEST_PRIORITY_SOURCE_CONCEPT_ID` | `UUID` | referral request priority concept id. | FK->[Concept](Concept.md).CONCEPT_ID |
-| `REFERRAL_REQUEST_TYPE_SOURCE_CONCEPT_ID` | `UUID` | referral request type concept id. | FK->[Concept](Concept.md).CONCEPT_ID |
-| `REFERRAL_REQUEST_SPECIALTY_SOURCE_CONCEPT_ID` | `UUID` | referral request specialty concept id. | FK->[Concept](Concept.md).CONCEPT_ID |
-| `MODE` | `VARCHAR` | mode. | |
-| `IS_OUTGOING_REFERRAL` | `BOOLEAN` | is outgoing referral. | |
-| `IS_REVIEW` | `BOOLEAN` | is review. | |
-| `REFERRAL_REQUEST_SOURCE_CONCEPT_ID` | `UUID` | referral request source concept id. | FK->[Concept](Concept.md).CONCEPT_ID |
-| `AGE_AT_EVENT` | `NUMBER` | age at event. | |
-| `AGE_AT_EVENT_BABY` | `NUMBER` | age at event baby. | |
-| `AGE_AT_EVENT_NEONATE` | `NUMBER` | age at event neonate. | |
-| `RECORDED_DATE` | `TIMESTAMP` | recorded date. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - |
-| `VALUE` | `DOUBLE` | value. | |
-| `CODE_ID` | `VARCHAR` | code id. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - | -- |
+| `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
+| `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | `encounter_id` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `UNIQUE_BOOKING_REFERENCE_NUMBER` | `VARCHAR` | unique booking reference number. | | -- |
+| `CLINICAL_EFFECTIVE_DATE` | `DATE` | clinical effective date. | | `clinical_effective_date` |
+| `CLINICAL_EFFECTIVE_DATE_PRECISION_SOURCE_CONCEPT_ID` | `UUID` | date precision concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `date_precision_concept_id` |
+| `REQUESTER_ORGANISATION_ID` | `UUID` | requester organisation id. | [ORANGANISATION](Organisation.md).ID | `requester_organization_id` |
+| `RECIPIENT_ORGANISATION_ID` | `UUID` | recipient organisation id. | [ORANGANISATION](Organisation.md).ID | `recipient_organization_id` |
+| `REFERRAL_REQUEST_PRIORITY_SOURCE_CONCEPT_ID` | `UUID` | referral request priority concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `referral_request_priority_concept_id` |
+| `REFERRAL_REQUEST_TYPE_SOURCE_CONCEPT_ID` | `UUID` | referral request type concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `referral_request_type_concept_id` |
+| `REFERRAL_REQUEST_SPECIALTY_SOURCE_CONCEPT_ID` | `UUID` | referral request specialty concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `referral_request_specialty_concept_id` |
+| `MODE` | `VARCHAR` | mode. | | `mode` |
+| `IS_OUTGOING_REFERRAL` | `BOOLEAN` | is outgoing referral. | | `outgoing_referral` |
+| `IS_REVIEW` | `BOOLEAN` | is review. | | `is_review` |
+| `REFERRAL_REQUEST_SOURCE_CONCEPT_ID` | `UUID` | referral request source concept id. | FK->[Concept](Concept.md).CONCEPT_ID | `raw_concept_id` |
+| `AGE_AT_EVENT` | `NUMBER` | age at event. | | `age_at_event` |
+| `AGE_AT_EVENT_BABY` | `NUMBER` | age at event baby. | | -- |
+| `AGE_AT_EVENT_NEONATE` | `NUMBER` | age at event neonate. | | -- |
+| `RECORDED_DATE` | `TIMESTAMP` | recorded date. | | `date_recorded` |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - | -- |
+| `VALUE` | `DOUBLE` | value. | | -- |
+| `CODE_ID` | `VARCHAR` | code id. | | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Schedule.md
+++ b/OLIDS/Documentation/Schema/Schedule.md
@@ -18,25 +18,25 @@ The schedule does not provide any information about actual appointments. This se
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `LOCATION_ID` | `UUID` | location id. | FK -> [Location](Location.md).ID |
-| `LOCATION_NAME` | `VARCHAR` | location. | |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `START_DATETIME` | `TIMESTAMP` | start date. | |
-| `END_DATETIME` | `TIMESTAMP` | end date. | |
-| `TYPE` | `VARCHAR` | type. | |
-| `NAME` | `VARCHAR` | name. | |
-| `IS_PRIVATE` | `BOOLEAN` | is private. | |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | `id` |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | | -- |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `LOCATION_ID` | `UUID` | location id. | FK -> [Location](Location.md).ID | -- |
+| `LOCATION_NAME` | `VARCHAR` | location. | | `location` |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
+| `START_DATETIME` | `TIMESTAMP` | start date. | | `start_date` |
+| `END_DATETIME` | `TIMESTAMP` | end date. | | -- |
+| `TYPE` | `VARCHAR` | type. | | `type` |
+| `NAME` | `VARCHAR` | name. | | `name` |
+| `IS_PRIVATE` | `BOOLEAN` | is private. | | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - | -- |
 
 ## Entity Relationships
 

--- a/OLIDS/Documentation/Schema/Schedule_Practitioner.md
+++ b/OLIDS/Documentation/Schema/Schedule_Practitioner.md
@@ -17,19 +17,19 @@ If the schedule needed to be consulted, then there would be one created covering
 
 ## Columns
 
-| Column Name | Data Type (Size) | Description | PK/FK |
-| --- | --- | --- | --- |
-| `ID` | `UUID` | id. | PK |
-| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. |  |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID |
-| `SCHEDULE_ID` | `UUID` | schedule id. | FK -> [Schedule](Schedule.md).ID |
-| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID |
-| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | |
-| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | |
-| `LDS_TRANSFORM_DATE_TIME` | `TIMESTAMP_LTZ` | lds transform date time. | |
+| Column Name | Data Type (Size) | Description | PK/FK | Compass Equivalent |
+| --- | --- | --- | --- | --- |
+| `ID` | `UUID` | id. | PK | -- |
+| `LDS_SOURCE_RECORD_ID` | `UUID` | Unique record identifier including file row number for deduplication. |  | -- |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
+| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
+| `SCHEDULE_ID` | `UUID` | schedule id. | FK -> [Schedule](Schedule.md).ID | -- |
+| `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | -- |
+| `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
+| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | | -- |
+| `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
+| `LDS_TRANSFORM_DATE_TIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 
 ## Entity Relationships
 


### PR DESCRIPTION
## What

Adds a **Compass Equivalent** column to each table in `OLIDS/Documentation/Schema/*.md` (22 files), restoring the mappings that were present in the archived Synapse schema dictionary but omitted from the new dbt schema docs in #89.

## How

- Values are taken from `Synapse-Platform-Archive/OLIDS-schema-dictionary.md`, matched by column name per table. Compass itself has not changed, so rows carry the new OLIDS column name with the old Compass value.
- Where columns were renamed in the rewrite, mappings were carried across manually where the equivalence is unambiguous (e.g. `SUBTYPE` <- `SUB_TYPE`, `RECORDED_DATE` <- `DATE_RECORDED`, `USUAL_GP_PRACTITIONER_IN_ROLE_ID` <- `CARE_MANAGER_PRACTITIONER_IN_ROLE_ID`, plus two archive typos).
- Columns new to the dbt build (`SOURCE_EXTRACTION_DATE`, `LDS_TRANSFORM_DATETIME`, `SLOT_ID`, etc.) show `--`, following the archive convention.
- Every mapping was then validated against the actual Compass source schema. A handful of archive values referenced columns that do not exist in Compass and were corrected: result units columns are `result_value_units` (not a concept id), supplier codings are `non_core_concept_id` (not `raw_concept_id`), `organisation`/`organization` spelling on two encounter columns, and Compass has no `age_at_event_baby`/`age_at_event_neonate`, birth date part, `clinical_status` or referral specialty columns (now `--`). `APPOINTMENT_PRACTITIONER.APPOINTMENT_ID` had an evident copy-paste value in the archive and is `--`.

## Notes

Four table rows in Patient_Address.md and Patient_Contact.md had fewer cells than their headers; they are padded so the new column aligns (also fixes four pre-existing MD056 lint errors). No other pre-existing content is modified, and markdownlint reports no new issues.