### PR TITLE
Documenting removal of `PUBLISHER_ORGANISATION_CODE` field from OLIDS practitioner tables

### DIFF
--- a/OLIDS/Documentation/Schema/Practitioner.md
+++ b/OLIDS/Documentation/Schema/Practitioner.md
@@ -51,7 +51,6 @@ The Practitioner resource is used for anyone involved in the provision of care o
 | `NAME` | `VARCHAR` | practitioners full name. | - | -- |
 | `IS_OBSOLETE` | `BOOLEAN` | is practitioner record obsolete. | - | -- |
 | `LDS_IS_DELETED` | `BOOLEAN` | is the practitioner record deleted in the source system. | - | -- |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | The ODS<sup>1<\sup> code of the organisation (data controller) who publishes the data. | - | -- |
 | `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | - | -- |
 | `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | the timestamp when the transform process that generated this record. | - | -- |
 

--- a/OLIDS/Documentation/Schema/Practitioner_In_Role.md
+++ b/OLIDS/Documentation/Schema/Practitioner_In_Role.md
@@ -49,7 +49,6 @@ For use cases where an organisation has activities where a practitioner is not d
 | `DATE_EMPLOYMENT_START` | `DATE` | date employment start. | | -- |
 | `DATE_EMPLOYMENT_END` | `DATE` | date employment end. | | -- |
 | `LDS_IS_DELETED` | `BOOLEAN` | True if the record has been marked as deleted. | | -- |
-| `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | ODS code of the owning organisation for this record. | | -- |
 | `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | Timestamp extracted from source file name indicating extraction time. | | -- |
 | `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_LTZ` | lds transform date time. | | -- |
 


### PR DESCRIPTION
updating documentation for `practitioner` and `practitioner_in_role` to reflect removal of `PUBLISHER_ORANISATION_CODE` from these tables allowing for full visibility of all practitioners across subscribers.
