### PR TITLE
Update schema documentation for Patient, Person, Practitioner, and Re…

### DIFF
--- a/OLIDS/Documentation/Schema/Patient.md
+++ b/OLIDS/Documentation/Schema/Patient.md
@@ -40,9 +40,8 @@ The data in the Resource covers the "who" information about the patient: its att
 | `PROVIDER_ORGANISATION_ID` | `UUID` | organisation id of the care provider<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | | -- |
 | `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | | -- |
 | `REGISTERED_PRACTICE_ORGANISATION_ID` | `UUID` | registered practice id. | FK -> [Organisation](Organisation.md).ID | | -- |
-| `DATE_OF_REGISTRATION` | `DATE` | date of registration. | | | -- |
-| `DATE_OF_DEACTIVATION` | `DATE` | date of deactivation. | | | -- |
-| `NHS_NUMBER` | `VARCHAR` | nhs number. | | ❌ column removed | `nhs_number` |
+| `LOCAL_PATIENT_ID` | `UUID` | The local administration system identifier for the patient | | | |
+| `NHS_NUMBER` | `VARCHAR` | NHS number. | | ❌ column removed | `nhs_number` |
 | `SK_PATIENT_ID` | `NUMBER` | sk patient id. | | ℹ️ pseudo view only | -- |
 | `TITLE` | `VARCHAR` | title. | | | `title` |
 | `FIRST_NAME` | `VARCHAR` | first name. | | ❌ column removed | `first_names` |

--- a/OLIDS/Documentation/Schema/Person.md
+++ b/OLIDS/Documentation/Schema/Person.md
@@ -3,6 +3,7 @@
 - [Person](#person)
   - [Overview](#overview)
   - [Columns](#columns)
+    - [columns to be added](#columns-to-be-added)
   - [Entity relationships](#entity-relationships)
   - [Notes](#notes)
 
@@ -29,13 +30,13 @@ PDS responses will always be used over an source system stub where both exist fo
 | `DATE_OF_BIRTH` | `VARCHAR` | Patient's date of birth. | | 📅 truncated to 1st of month | -- |
 | `DATE_OF_BIRTH_YEAR` | `BIGINT` | Year component of DATE_OF_BIRTH. | | | -- |
 | `DATE_OF_BIRTH_MONTH` | `BIGINT` | Month component of DATE_OF_BIRTH. | | | -- |
-| `DATE_OF_BIRTH_DAY` | `BIGINT` | Day component of DATE_OF_BIRTH. | | ❌ column removed | -- |
-| `DATE_OF_BIRTH_TIME` | `TIME` | Time component of DATE_OF_BIRTH. Always NULL — neither PDS nor EMIS provides a time-of-birth value. | | ❌ column removed | -- |
+| `DATE_OF_BIRTH_DAY` | `BIGINT` | Day component of DATE_OF_BIRTH. | | 📅 truncated to 1st of month | -- |
+| `DATE_OF_BIRTH_TIME` | `TIME` | Time component of DATE_OF_BIRTH. Always NULL — neither PDS nor EMIS provides a time-of-birth value. | | 📅 nullified | -- |
 | `DATE_OF_DEATH` | `VARCHAR` | Patient's date of death. NULL if the patient is living. | | 📅 truncated to 1st of month | -- |
 | `DATE_OF_DEATH_YEAR` | `BIGINT` | Year component of DATE_OF_DEATH. | | | -- |
 | `DATE_OF_DEATH_MONTH` | `BIGINT` | Month component of DATE_OF_DEATH. | | | -- |
-| `DATE_OF_DEATH_DAY` | `BIGINT` | Day component of DATE_OF_DEATH. | | ❌ column removed | -- |
-| `DATE_OF_DEATH_TIME` | `TIME` | Time component of DATE_OF_DEATH. Always NULL — neither PDS nor EMIS provides a time-of-death value. | | ❌ column removed | -- |
+| `DATE_OF_DEATH_DAY` | `BIGINT` | Day component of DATE_OF_DEATH. | | 📅 truncated to 1st of month | -- |
+| `DATE_OF_DEATH_TIME` | `TIME` | Time component of DATE_OF_DEATH. Always NULL — neither PDS nor EMIS provides a time-of-death value. | | 📅 nullified | -- |
 | `DEATH_NOTIFICATION_STATUS` | `VARCHAR` | PDS death notification status code. NULL for EMIS stub rows. | | | -- |
 | `ADDRESS_LINE1` | `VARCHAR` | First line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
 | `ADDRESS_LINE2` | `VARCHAR` | Second line of the patient's address. NULL for EMIS stub rows. | | ❌ column removed | -- |
@@ -57,12 +58,18 @@ PDS responses will always be used over an source system stub where both exist fo
 | `MOBILE_NUMBER` | `VARCHAR` | Patient's mobile number from PDS. NULL for EMIS stub rows. | | ❌ column removed | -- |
 | `EMAIL_ADDRESS` | `VARCHAR` | Patient's email address from PDS. NULL for EMIS stub rows. | | ❌ column removed | -- |
 | `MPS_ID` | `VARCHAR` | Master Patient Service identifier from PDS. NULL for EMIS stub rows. | | | -- |
-| `SENSITIVITY_FLAG` | `VARCHAR` | Always NULL in this model. The source SENSITIVITY_FLAG from PDS is intentionally overridden with CAST(NULL AS VARCHAR(1)) to prevent accidental disclosure of sensitive flagging in downstream consumers. | | | -- |
+| `PATIENT_FLAGGED_SENSITIVE` | `BOOLEAN` | True where patient is flagged as sensitive. | | | -- |
 | `ERROR_SUCCESS_CODE` | `VARCHAR` | PDS response error_success code (sourced from the ERROR_SUCCESS_CODE column in PDS_DATA_MASKED). For EMIS stub rows, set to '92' when SPINE_SENSITIVE is TRUE; otherwise NULL. | | | -- |
 | `LDS_IS_DELETED` | `BOOLEAN` | Indicates whether the source record has been logically deleted. Always FALSE for PDS rows (the PDS source has no deleted column). Inherited from the Admin_Patient source for EMIS stub rows. | | | -- |
 | `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | The timestamp when the source record was acquired or supplied to LDS | | | -- |
 | `LDS_TRANSFORM_DATETIME` | `TIMESTAMP` | The timestamp when the source record was transformed by LDS | | | -- |
-| `Source` | `VARCHAR` | Indicates the origin of the person record. 'Person' for records sourced from PDS (Person_Sequenced); 'EMIS' for stub records sourced from Admin_Patient_Sequenced where no PDS response exists. | | | -- |
+
+### columns to be added
+
+| Column Name | Data Type (Size) | Description | PK/FK | Masking Policy | Compass Equivalent |
+| --- | --- | --- | --- | --- | --- |
+| `LDS_SOURCE_DATASET` | `VARCHAR` | Indicates the origin of the person record. 'Person' for records sourced from PDS (Person_Sequenced); 'EMIS' for stub records sourced from Admin_Patient_Sequenced where no PDS response exists. | | | -- |
+| `IS_PATIENT_FLAGGED_SENSITIVE` | `BOOLEAN` | will replace/rename `PATIENT_FLAGGED_SENSITIVE`. | | | -- |
 
 ## Entity relationships
 

--- a/OLIDS/Documentation/Schema/Practitioner.md
+++ b/OLIDS/Documentation/Schema/Practitioner.md
@@ -42,8 +42,8 @@ The Practitioner resource is used for anyone involved in the provision of care o
 | --- | --- | --- | --- | --- |
 | `ID` | `UUID` | id. | PK | `id` |
 | `LDS_SOURCE_RECORD_ID` | `UUID` | lds record id. | - | -- |
-| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher^1^. | FK -> [Organisation](Organisation.md).ID | -- |
-| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author^1^. | FK -> [Organisation](Organisation.md).ID | -- |
+| `PUBLISHER_ORGANISATION_ID` | `UUID` | organisation id of the record publisher<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | -- |
+| `AUTHOR_ORGANISATION_ID` | `UUID` | organisation id record author<sup>1</sup>. | FK -> [Organisation](Organisation.md).ID | -- |
 | `GMC_CODE` | `VARCHAR` | general medical council code | - | `gmc_code` |
 | `TITLE` | `VARCHAR` | practitioners title. | - | -- |
 | `FIRST_NAME` | `VARCHAR` | practitioners first/given name. | - | `name` |

--- a/OLIDS/Documentation/Schema/Referral_Request.md
+++ b/OLIDS/Documentation/Schema/Referral_Request.md
@@ -39,7 +39,6 @@ ReferralRequest is also intended for use when there is a complete and more perma
 | `PATIENT_ID` | `UUID` | patient id. | FK -> [Patient](Patient.md).ID | `patient_id` |
 | `PERSON_ID` | `UUID` | person id. | FK -> [Person](Person.md).ID | `person_id` |
 | `PUBLISHER_ORGANISATION_ID` | `UUID` | linked organisaiton id publisher. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
-| `PROVIDER_ORGANISATION_ID` | `UUID` | linked organisaiton id provider. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | -- |
 | `AUTHOR_ORGANISATION_ID` | `UUID` | linked organisaiton id author. see [schema notes: publisher, provider, author](_schema_notes.md#provider-author-publisher-organisation-id) | FK -> [ORANGANISATION](Organisation.md).ID | `organization_id` |
 | `ENCOUNTER_ID` | `UUID` | encounter id. | FK -> [Encounter](Encounter.md).ID | `encounter_id` |
 | `PRACTITIONER_ID` | `UUID` | practitioner id. | FK -> [Practitioner](Practitioner.md).ID | `practitioner_id` |
@@ -58,13 +57,12 @@ ReferralRequest is also intended for use when there is a complete and more perma
 | `AGE_AT_EVENT` | `NUMBER` | age at event. | | `age_at_event` |
 | `AGE_AT_EVENT_BABY` | `NUMBER` | age at event baby. | | -- |
 | `AGE_AT_EVENT_NEONATE` | `NUMBER` | age at event neonate. | | -- |
-| `RECORDED_DATE` | `TIMESTAMP` | recorded date. | | `date_recorded` |
+| `RECORDED_DATETIME` | `TIMESTAMP` | recorded date. | | `date_recorded` |
+| `VALUE` | `DOUBLE` | value. | | -- |
 | `LDS_IS_DELETED` | `BOOLEAN` | lds is deleted. | | -- |
 | `PUBLISHER_ORGANISATION_CODE` | `VARCHAR` | record owner organisation code. | | -- |
 | `SOURCE_EXTRACTION_DATE` | `TIMESTAMP` | source extraction date. | | -- |
 | `LDS_TRANSFORM_DATETIME` | `TIMESTAMP_NTZ` | The timestamp when the record was transformed by LDS into OLIDS. | - | -- |
-| `VALUE` | `DOUBLE` | value. | | -- |
-| `CODE_ID` | `VARCHAR` | code id. | | -- |
 
 ## Entity Relationships
 


### PR DESCRIPTION
Document updates

- PATIENT:
   - removed `DATE_OF_REGISTRATION`, `DATE_OF_DEACTIVATION`
   - added `LOCAL_PATIENT_ID`
   
- PERSON:
  - updated `DATE_OF_BIRTH_DAY`, `DATE_OF_BIRTH_TIME`, `DATE_OF_DEATH_DAY`, `DATE_OF_DEATH_TIME  to note as present but truncated in pseudo views
  - updated name of column from `SENSITIVITY_FLAG` to correct name `PATIENT_FLAGGED_SENSITIVE`
  - added note for expected schema changes: `PATIENT_FLAGGED_SENSITIVE` to be prefixed with "IS_" for directionality, `LDS_SOURCE_DATASET` column expected to be added

- PRACTITIONER:
  - docrub: corrected malformed superscript

- REFERRAL_REQUEST:
  - removed: `PROVIDER_ORGANISATION_ID` as no longer present in table, 
  - removed: `CODE_ID` as never present in table
  - ordinal change: `VALUE` repositioned to correct location
  - rename: `RECORDED_DATE` corrected to `RECORDED_DATETIME` (as timestamp).