### PR TITLE
Olids flag note

### DIFF
--- a/OLIDS/Documentation/Schema/Allergy_Intolerance.md
+++ b/OLIDS/Documentation/Schema/Allergy_Intolerance.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Allergy Intolerance](https://hl7.org/fhir/allergyintolerance.html)
+
 Risk of harmful or undesirable physiological response which is specific to an individual and associated with exposure to a substance. A record of a clinical assessment of an allergy or intolerance; a propensity, or a potential risk to an individual, to have an adverse reaction on future exposure to the specified substance, or class of substance.
 
 Where a propensity is identified, to record information or evidence about a reaction event that is characterised by any harmful or undesirable physiological response that is specific to the individual and triggered by exposure of an individual to the identified substance or class of substance.

--- a/OLIDS/Documentation/Schema/Appointment.md
+++ b/OLIDS/Documentation/Schema/Appointment.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Appointment](https://hl7.org/fhir/appointment.html)
+
 A booking of a healthcare event among patient(s), practitioner(s), related person(s) and/or device(s) for a specific date/time. This may result in one or more Encounter(s).
 
 Appointment resources are used to provide information about a planned meeting that may be in the future or past. The resource only describes a single meeting, a series of repeating visits would require multiple appointment resources to be created for each instance. Examples include a scheduled surgery, a follow-up for a clinical visit, a scheduled conference call between clinicians to discuss a case (where the patient is a subject, but not a participant), the reservation of a piece of diagnostic equipment for a particular use, etc. The visit scheduled by an appointment may be in person or remote (by phone, video conference, etc.) All that matters is that the time and usage of one or more individuals, locations and/or pieces of equipment is being fully or partially reserved for a designated period of time.

--- a/OLIDS/Documentation/Schema/Appointment_Practitioner.md
+++ b/OLIDS/Documentation/Schema/Appointment_Practitioner.md
@@ -9,6 +9,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Appointment.Participant](https://hl7.org/fhir/appointment-definitions.html#Appointment.participant)
+
 List of practitioner participants involved in an appointment.
 
 > [!NOTE]

--- a/OLIDS/Documentation/Schema/Diagnostic_Order.md
+++ b/OLIDS/Documentation/Schema/Diagnostic_Order.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Service Request](https://hl7.org/fhir/servicerequest.html)
+
 A record of a request for service such as diagnostic investigations, treatments, or operations to be performed.
 
 This represents an order or proposal or plan to perform a diagnostic or other service on or for a patient. It represents a proposal or plan or order for a service to be performed that would result in a Procedure or Diagnostic Report, which in turn may reference one or more Observations, which summarize the performance of the procedures and associated documentation such as observations, images, findings that are relevant to the treatment/management of the subject. This resource may be used to share relevant information required to support a referral or a transfer of care request from one practitioner or organization to another when a patient is required to be referred to another provider for a consultation /second opinion and/or for short term or longer term management of one or more health issues or problems.

--- a/OLIDS/Documentation/Schema/Encounter.md
+++ b/OLIDS/Documentation/Schema/Encounter.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Encounter](https://hl7.org/fhir/encounter.html)
+
 An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.
 
 A patient encounter is further characterized by the setting in which it takes place. Amongst them are ambulatory, emergency, home health, inpatient and virtual encounters. An Encounter encompasses the lifecycle from pre-admission, the actual encounter (for ambulatory encounters), and admission, stay and discharge (for inpatient encounters). During the encounter the patient may move from practitioner to practitioner and location to location.

--- a/OLIDS/Documentation/Schema/Episode_Of_Care.md
+++ b/OLIDS/Documentation/Schema/Episode_Of_Care.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Episode of Care](https://hl7.org/fhir/episodeofcare.html)
+
 An association between a patient and an organisation / healthcare provider(s) during which time encounters may occur. The managing organisation assumes a level of responsibility for the patient during this time.
 
 ## Columns

--- a/OLIDS/Documentation/Schema/Flag.md
+++ b/OLIDS/Documentation/Schema/Flag.md
@@ -1,0 +1,36 @@
+# Flag
+
+- [Flag](#flag)
+  - [Overview](#overview)
+  - [Columns](#columns)
+
+## Overview
+
+> [!IMPORTANT]
+> The Flag table will **not** be provided during testing of Primary Care EMIS data.
+> <br>There is no mapping currently undertaken from Primary Care EMIS data to the Flag entity
+> <br>The Flag object is expected to be populated as part of Primary Care TPP mapping.
+
+Linked FHIR resource: [🔥 Flag](https://build.fhir.org/flag.html)
+
+A flag is a warning or notification of some sort presented to the user - who may be a clinician or some other person involved in patient care. It usually represents something of sufficient significance to warrant a special display of some sort - rather than just a note in the resource. A flag has a subject representing the resource that will trigger its display. This subject can be of different types, as described in the examples below:
+
+- A note that a patient has an overdue account, which the provider may wish to discuss with them - in case of hardship for example (subject = Patient)
+- An outbreak of Ebola in a particular region (subject=Location) so that all patients from that region have a higher risk of having that condition
+- A particular provider is unavailable for referrals over a given period (subject = Practitioner)
+- A patient who is enrolled in a clinical trial (subject=Group)
+- Special guidance or caveats to be aware of when following a protocol (subject=PlanDefinition)
+- Warnings about using a drug in a formulary requires special approval (subject=Medication)
+
+A flag is typically presented as a label in a prominent location in the record to notify the clinician of the potential issues, though it may also appear in other contexts; e.g. notes applicable to a radiology technician, or to a clinician performing a home visit. For patients, the information in the flag will often be derived from the record, and therefore, for a thorough and careful clinician, who has the time to review the notes will be redundant. However, given the volume of information frequently found in patients' records and the potentially serious consequences of losing sight of some facts, this redundancy is deemed appropriate. As well, some flags may reflect information not captured by any other resource in the record. (E.g. "Patient has large dog at home")
+
+Examples of Patient related issues that might appear in flags:
+
+- Risks to the patient (functional risk of falls, spousal restraining order, latex allergy)
+- Patient's needs for special accommodations (hard of hearing, need for easy-open caps)
+- Risks to providers (dog in house, patient may bite, infection control precautions)
+- Administrative concerns (incomplete information, prepayment required due to credit risk)
+
+## Columns
+
+<To be added>

--- a/OLIDS/Documentation/Schema/Location.md
+++ b/OLIDS/Documentation/Schema/Location.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Location](https://hl7.org/fhir/location.html)
+
 Details and position information for a place where services are provided and resources and participants may be stored, found, contained, or accommodated.
 
 A Location includes both incidental locations (a place which is used for healthcare without prior designation or authorization) and dedicated, formally appointed locations. Locations may be private, public, mobile or fixed and scale from small freezers to full hospital buildings or parking garages.

--- a/OLIDS/Documentation/Schema/Medication_Order.md
+++ b/OLIDS/Documentation/Schema/Medication_Order.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Linked FHIR resource: [🔥 Medication Request](https://build.fhir.org/medicationrequest.html)
+Linked FHIR resource: [🔥 Medication Request](https://hl7.org/fhir/medicationrequest.html)
 
 This resource covers all type of orders for medications for a patient. This includes inpatient medication orders as well as community orders (whether filled by the prescriber or by a pharmacy). It also includes orders for over-the-counter medications (e.g., Aspirin), total parenteral nutrition and diet/vitamin supplements. It may be used to support the order of medication-related devices e.g., prefilled syringes such as patient-controlled analgesia (PCA) syringes, or syringes used to administer other types of medications. e.g., insulin, narcotics. It can can also be used to order medication or substances NOT be taken.
 

--- a/OLIDS/Documentation/Schema/Medication_Statement.md
+++ b/OLIDS/Documentation/Schema/Medication_Statement.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Linked FHIR resource: [🔥 Medication Statement](https://build.fhir.org/medicationstatement.html)
+Linked FHIR resource: [🔥 Medication Statement](https://hl7.org/fhir/medicationstatement.html)
 
 A record of a medication that is being consumed by a patient. A MedicationStatement may indicate that the patient may be taking the medication now or has taken the medication in the past or will be taking the medication in the future. The source of this information can be the patient, significant other (such as a family member or spouse), or a clinician. A common scenario where this information is captured is during the history taking process during a patient visit or stay. The medication information may come from sources such as the patient's memory, from a prescription bottle, or from a list of medications the patient, clinician or other party maintains.
 

--- a/OLIDS/Documentation/Schema/Observation.md
+++ b/OLIDS/Documentation/Schema/Observation.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Observation](https://hl7.org/fhir/observation.html)
+
 Measurements and simple assertions made about a patient, device or other subject
 
 Observations are a central element in healthcare, used to support diagnosis, monitor progress, determine baselines and patterns and even capture demographic characteristics, as well as capture results of tests performed on products, substances, and environments. Most observations are simple name/value pair assertions with some metadata, but some observations group other observations together logically, or even are multi-component observations. Note that the DiagnosticReport resource provides a clinical or workflow context for a set of observations and the Observation resource is referenced by DiagnosticReport to represent laboratory, imaging, and other clinical and diagnostic data to form a complete report.

--- a/OLIDS/Documentation/Schema/Organisation.md
+++ b/OLIDS/Documentation/Schema/Organisation.md
@@ -8,7 +8,8 @@
 
 ## Overview
 
-Linked FHIR resource: [🔥 Organization](https://build.fhir.org/organization.html)
+Linked FHIR resource: [🔥 Organization](https://hl7.org/fhir/organization.html)
+
 The Organisation resource is used for collections of people that have come together to achieve an objective. The Group resource is used to identify a collection of people (or animals, devices, etc.) that are gathered for the purpose of analysis or acting upon, but are not expected to act themselves.
 
 In the context of service provision, the Organisation provides the services, the HealthcareService describes the services provided, and the Location describes the place where the service(s) are offered/available.

--- a/OLIDS/Documentation/Schema/Patient.md
+++ b/OLIDS/Documentation/Schema/Patient.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Related FHIR resource: [🔥 Patient](https://build.fhir.org/patient.html)
+Related FHIR resource: [🔥 Patient](https://hl7.org/fhir/patient.html)
 
 This Resource covers data about patients involved in a wide range of health-related activities, including:
 

--- a/OLIDS/Documentation/Schema/Patient_Address.md
+++ b/OLIDS/Documentation/Schema/Patient_Address.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Related FHIR resource: [🔥 Patient.address](https://build.fhir.org/patient-definitions.html#Patient.address)
+Related FHIR resource: [🔥 Patient.address](https://hl7.org/fhir/patient-definitions.html#Patient.address)
 
 Patient addresses with different uses or applicable periods.
 

--- a/OLIDS/Documentation/Schema/Patient_Contact.md
+++ b/OLIDS/Documentation/Schema/Patient_Contact.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Related FHIR resource [🔥 Patient.telecom](https://build.fhir.org/patient-definitions.html#Patient.telecom)
+Related FHIR resource [🔥 Patient.telecom](https://hl7.org/fhir/patient-definitions.html#Patient.telecom)
 
 A Patient may have multiple ways to be contacted with different uses or applicable periods. May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).
 

--- a/OLIDS/Documentation/Schema/Patient_UPRN.md
+++ b/OLIDS/Documentation/Schema/Patient_UPRN.md
@@ -7,6 +7,7 @@
   - [Notes](#notes)
 
 ## Overview
+
 Provides a resolved Unique Property Reference Number (or pseudonym thereof) against the patient address.
 
 ## Columns

--- a/OLIDS/Documentation/Schema/Practitioner.md
+++ b/OLIDS/Documentation/Schema/Practitioner.md
@@ -20,6 +20,8 @@
   
 ## Overview
 
+Linked FHIR resource: [🔥 Practitioner](https://hl7.org/fhir/practitioner.html)
+
 Practitioner covers all individuals who are engaged in the healthcare process and healthcare-related services as part of their formal responsibilities and this Resource is used for attribution of activities and responsibilities to these individuals. Practitioners include (but are not limited to):
 
 - physicians, dentists, pharmacists

--- a/OLIDS/Documentation/Schema/Practitioner_In_Role.md
+++ b/OLIDS/Documentation/Schema/Practitioner_In_Role.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Linked FHIR resource [🔥 PractitionerRole](https://build.fhir.org/practitionerrole.html)
+Linked FHIR resource [🔥 PractitionerRole](https://hl7.org/fhir/practitionerrole.html)
 
 A specific set of Roles/Locations/specialties/services that a practitioner may perform at an organisation for a period of time
 

--- a/OLIDS/Documentation/Schema/Schedule.md
+++ b/OLIDS/Documentation/Schema/Schedule.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Related FHIR component: [Schedule](https://build.fhir.org/schedule.html)
+Linked FHIR resource: [🔥 Schedule](https://build.fhir.org/schedule.html)
 
 A container for slots of time that may be available for booking appointments
 

--- a/OLIDS/Documentation/Schema/Schedule_Practitioner.md
+++ b/OLIDS/Documentation/Schema/Schedule_Practitioner.md
@@ -8,6 +8,8 @@
 
 ## Overview
 
+Linked FHIR resource: [🔥 Schedule.Actor](https://hl7.org/fhir/schedule-definitions.html#Schedule.actor)
+
 The schedule belongs to a single instance of a service or resource. This is normally a HealthcareService, Practitioner, Location or Device. In the case where a single resource can provide different services, potentially at different location, then the schedulable resource is considered the composite of the actors.
 
 For example, if a practitioner can provide services at multiple locations, they might have one schedule per location, where each schedule includes both the practitioner and location actors. When booking an appointment with multiple schedulable resources, multiple schedules may need to be checked depending on the configuration of the system.


### PR DESCRIPTION
introduces a new documentation file for the `Flag` entity and enhances the documentation for several schema files by adding or updating references to the relevant FHIR resources, ensuring clearer traceability and alignment with FHIR standards. (It also updates some resource links to point to the canonical HL7 FHIR URLs.)

**New Documentation:**

* Added a new documentation file for the `Flag` entity, including an overview, usage notes, and FHIR mapping information. This file also documents that the `Flag` table is not populated from Primary Care EMIS data but is expected to be used for Primary Care TPP mapping.

**FHIR Resource Reference Updates:**

* Added or updated "Linked FHIR resource" sections in the overview of the following schema documentation files for better clarity and direct reference:
  - `Allergy_Intolerance.md`, `Appointment.md`, `Appointment_Practitioner.md`, `Diagnostic_Order.md`, `Encounter.md`, `Episode_Of_Care.md`, `Location.md`, `Observation.md`, `Organisation.md`, `Patient.md`, `Patient_Address.md`, `Patient_Contact.md`, `Practitioner.md`, `Practitioner_In_Role.md`, `Schedule.md`, `Schedule_Practitioner.md` [[1]](diffhunk://#diff-8abd08868b13136e976c8f4bac2d4f362130b56e27b3b0cc2bd775631bb51af9R11-R12) [[2]](diffhunk://#diff-32634b433c8ba66faea3beecd3681c20de8d65d3493717a428768d751156aae0R11-R12) [[3]](diffhunk://#diff-1aa50fddffee7d20d5e1ea909f45be03ee5a87c48bbfa60b49910240750bc3b1R12-R13) [[4]](diffhunk://#diff-f10641693766763a16f18e45a3ba07e0acad39cdd4ccc215d28bee6273482200R11-R12) [[5]](diffhunk://#diff-9ae9b838c3188de42714badf1a173d5fd955254ec97c526f1e91282dad5713aaR11-R12) [[6]](diffhunk://#diff-c0a22ebde1be54cd620b3b4f65d3c4dcf8d81bdd394cba4dc49a68c3b59e652cR11-R12) [[7]](diffhunk://#diff-c762a5771761eb6c108b6d6c54402aac3ea0759698daccc5f4d565d18af87039R11-R12) [[8]](diffhunk://#diff-7fe2883df2afa586cc3b1203b893f368e4d67582777d7c726c556ba4ad07e0e9R5-R6) [[9]](diffhunk://#diff-01bb47f744832f7a2f6241f85e6bb80a69fe1c89bdf6b0e5923729cea3a7aa92L11-R12) [[10]](diffhunk://#diff-9c792b47c19c2499e79361ad4eb562b40fb67423884e6bc949c1b2e567168c27L11-R11) [[11]](diffhunk://#diff-35c02070939450ff04cc6afcda419ca264964be8f3e8b546d000aa3e8ba9172bL12-R12) [[12]](diffhunk://#diff-2710b830efae6505a44488ca548096f00f660b55e7169f2332bd4c0786c0109fL11-R11) [[13]](diffhunk://#diff-ec2e93d830af945d93fdb4f07f9279c4b00bd4aeb69f29a8f3f230e25ea3264cR23-R24) [[14]](diffhunk://#diff-6e3c4ff87f766a74181356c5191df54baa81c60f7fddf2af1402a7d5859e2db5L11-R11) [[15]](diffhunk://#diff-1617a81f7571c361c57e42f7afcc98e3a3a77443bf9e01e0a7d7fd93970d030fL11-R11) [[16]](diffhunk://#diff-6d62e95e0c363a63df18d05df87eb5ab2c6df08735ced819d84c2bf6cbc3343bR11-R12).

* Updated FHIR resource URLs to point to the canonical HL7 FHIR domain (`hl7.org/fhir`) rather than the build site for improved stability and accuracy:
  - `Medication_Order.md`, `Medication_Statement.md`, `Organisation.md`, `Patient.md`, `Patient_Address.md`, `Patient_Contact.md`, `Practitioner_In_Role.md` [[1]](diffhunk://#diff-2cc2ad2e5b1496e55d2ee8fa3c291ffb0f40a3e6682b36bf8c3d7679332b13b7L11-R11) [[2]](diffhunk://#diff-5840716f42a15388021f95de6cf55a9a2f3a2b7c54236b3362e4949aeb9fd12fL11-R11) [[3]](diffhunk://#diff-01bb47f744832f7a2f6241f85e6bb80a69fe1c89bdf6b0e5923729cea3a7aa92L11-R12) [[4]](diffhunk://#diff-9c792b47c19c2499e79361ad4eb562b40fb67423884e6bc949c1b2e567168c27L11-R11) [[5]](diffhunk://#diff-35c02070939450ff04cc6afcda419ca264964be8f3e8b546d000aa3e8ba9172bL12-R12) [[6]](diffhunk://#diff-2710b830efae6505a44488ca548096f00f660b55e7169f2332bd4c0786c0109fL11-R11) [[7]](diffhunk://#diff-6e3c4ff87f766a74181356c5191df54baa81c60f7fddf2af1402a7d5859e2db5L11-R11).
