### PR TITLE
Add guidance on handling unmatched patient IDs in appointment records

### DIFF
--- a/OLIDS/Documentation/Schema/Appointment.md
+++ b/OLIDS/Documentation/Schema/Appointment.md
@@ -113,3 +113,25 @@ Users should not expect all `PATIENT_ID` values contained in the `APPOINTMENT` t
 
 - Users should expect all appointments **within five years of the initial practice bulk** to relate to `PATIENT_ID` values that are present within the `PATIENT` table.
 - Users should expect appointments five or more years prior to the initial bulk may contain `PATIENT_ID` values that do not exist in the `PATIENT` table.
+
+The query below is shown as a guide to visualising the impact of this issue:
+
+```sql
+SELECT
+  YEAR(START_DATE) AS APPOINTMENT_YEAR
+, MONTH(START_DATE) AS APPOINTMENT_MONTH
+, COUNT_IF(P.ID IS NULL) AS UNMATCHED_COUNT
+, COUNT_IF(P.ID IS NOT NULL) AS MATCHED_COUNT
+, COUNT(A.PATIENT_ID) AS PATIENT_COUNT
+
+FROM OLIDS_PSEUDO.APPOINTMENT AS A
+LEFT JOIN OLIDS_PSEUDO.PATIENT AS P
+    ON A.PATIENT_ID = P.ID
+
+GROUP BY 
+  YEAR(START_DATE)
+, MONTH(START_DATE)
+ORDER BY APPOINTMENT_YEAR DESC, APPOINTMENT_MONTH DESC;
+```
+
+Users will see the number of `UNMATCHED_COUNT` results increase significantly around five years prior to the commencement of services depending upon when practices signed up to the service (therefore anytime between 2020 and 2021).


### PR DESCRIPTION
This pull request adds a practical example to the appointment documentation, helping users understand how to identify and visualize unmatched `PATIENT_ID` values in the `APPOINTMENT` table. The main change is the inclusion of a sample SQL query and an explanation of its results.

Documentation improvements:

* Added a sample SQL query to `OLIDS/Documentation/Schema/Appointment.md` that demonstrates how to count matched and unmatched `PATIENT_ID` values in the `APPOINTMENT` table by year and month.
* Provided guidance on interpreting the results, clarifying that unmatched counts increase for appointments more than five years before the initial bulk upload.