### PR TITLE
Add release notes for OLIDS - v1.2.0

### DIFF
--- a/OLIDS/Release-notes/2_EMIS_OLIDS/v1.2.0.md
+++ b/OLIDS/Release-notes/2_EMIS_OLIDS/v1.2.0.md
@@ -1,0 +1,57 @@
+# Release v1.2.0 - 2026-07-22
+
+- [Release v1.2.0 - 2026-07-22](#release-v120---2026-07-22)
+  - [Summary](#summary)
+    - [Dependency changes](#dependency-changes)
+    - [Improvements](#improvements)
+    - [Bug Fixes](#bug-fixes)
+    - [Inputs](#inputs)
+  - [Full Details](#full-details)
+
+> [!NOTE]
+> The below is a summary of the changes since the previous release [V1.1.0](v1.1.0.md).
+
+<!--- original link [V1.1.0](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/releases/tag/releases%2FV1.1.0) --->
+
+## Summary
+
+This release delivers significant performance and data quality enhancements to the EMIS OLIDS transformation pipeline. Key changes include improved logic for identifying referral requests, targeted bug fixes to prevent duplicate IDs, and the introduction of clustering to boost query performance for RAP-enabled tables. These updates enhance both the accuracy and efficiency of the platform, supporting more reliable and faster data processing.
+
+### Dependency changes
+
+- OLIDS_Share: [v1.1.0](../1_OLIDS_Share/v1.1.0.md) - No change
+
+### Improvements
+
+- Add clustering on `publisher_organisation_code` to all transform tables with RAP applied, and on `GP_Practice` to the person table, to improve query performance. Benchmarking shows significant speed improvements for eligibility lookups. *[PR: [#105](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/pull/105)]*
+  > 🎯 ***Impact:*** Data is now sorted by organisation code at write time, making RAP queries faster and more efficient across large datasets. Addresses Bug Item [#29807](https://dev.azure.com/NELAnalytics/LondonDataService/_workitems/edit/29807)
+
+### Bug Fixes
+
+- Fix duplicate IDs for referral requests by updating the join condition in `PC_EMIS_Referral_Request` to use LDS Business ID instead of raw GUIDs, and add a unit test to ensure no duplicates are created when a user GUID has multiple values. *[PR: [#103](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/pull/103)]*
+  > 🐞 ***Fix:*** Prevents erroneous duplicate referral request IDs, improving data quality and downstream reliability.
+
+- Refactor referral request logic to rely exclusively on the code category for identifying referrals, ignoring the `OBSERVATION_TYPE` field, and update unit tests for accuracy. Additional tests ensure only valid referral records are included. *[PR: [#104](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/pull/104), WorkItems: [AB#29853](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29853)]*
+  > 🐞 ***Fix:*** Streamlines and clarifies referral identification logic, reducing ambiguity and improving test coverage for future maintainability. Fixes bug item [#29853](https://dev.azure.com/NELAnalytics/LondonDataService/_workitems/edit/29853)
+
+### Inputs
+
+This changelog was automatically produced from:
+
+- 3 Pull Requests
+- 0 Issues
+- 1 WorkItems
+- 18 Commits
+
+## Full Details
+
+Pull Requests included in this release:
+
+- [PR #103](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/pull/103): Fix Bug 29822 - Duplicate IDs for referral request
+  - No linked issues.
+- [PR #104](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/pull/104): Refactor referral request logic and improve test coverage
+  - [WorkItem AB#29853](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29853)
+- [PR #105](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/pull/105): Add clustering on publisher_organisation_code to all transform tables to improve RAP performance
+  - No linked issues.
+
+[View the diff between V1.1.0 and V1.2.0](https://github.com/NHSISL/LondonDataservices.Transform.EMIS_OLIDS/compare/releases%2FV1.1.0...releases%2FV1.2.0)

--- a/OLIDS/Release-notes/3_OLIDS_Enrichment/v1.2.0.md
+++ b/OLIDS/Release-notes/3_OLIDS_Enrichment/v1.2.0.md
@@ -1,0 +1,60 @@
+# Release v1.2.0 - 2026-07-22
+
+- [Release v1.2.0 - 2026-07-22](#release-v120---2026-07-22)
+  - [Summary](#summary)
+    - [Dependency changes](#dependency-changes)
+    - [Improvements](#improvements)
+    - [Bug Fixes](#bug-fixes)
+    - [Inputs](#inputs)
+  - [Full Details](#full-details)
+
+> [!NOTE]
+> The below is a summary of the changes since the previous release [V1.1.0](v1.1.0.md).
+
+## Summary
+
+This release focuses on improving data quality and reliability within the OLIDS Enrichment pipeline. Key updates include a critical fix to address deduplication logic for UPRN ranking, enhancements to the release pipeline for more consistent deployments, and the removal of an unused field from queries to streamline data processing. Additionally, the EMIS_OLIDS package version has been updated, ensuring alignment with the latest standards.
+
+### Dependency changes
+
+- OLIDS_SHARE: [v1.1.0](../1_OLIDS_Share/v1.1.0.md)  (no change)
+- EMIS_OLIDS: [v1.2.0](../2_EMIS_OLIDS/v1.2.0.md) (⬆️ upgrade)
+
+### Improvements
+
+- Change release pipeline so amended views default is true ([#44](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/44))
+  > 🎯 ***Impact:*** The release pipeline now defaults to automatically recreating amended final views during overnight runs, ensuring that all changes to final views are consistently deployed without manual intervention.
+
+- Remove PUBLISHER_ORGANISATION_CODE from query ([#47](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/47))
+  > 🎯 ***Impact:*** The query no longer selects the unused `PUBLISHER_ORGANISATION_CODE` field, reducing unnecessary data handling and simplifying downstream processing. Fixes work item [#29864](https://dev.azure.com/NELAnalytics/LondonDataService/_workitems/edit/29864)
+
+- Update revision for EMIS_OLIDS to V1.2.0 ([#48](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/48))
+  > 🎯 ***Impact:*** Updates the EMIS_OLIDS package revision, ensuring the deployment is aligned with the latest release and benefits from recent improvements.
+
+### Bug Fixes
+
+- Bug 29849 - correct uprn ranking mismatch ([#46](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/46), WorkItems: [AB#29849](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29849))
+  > 🐞 ***Fix:*** Corrects the deduplication logic in the `Address_UPRN_Response` model to ensure only the latest record per hashed address is flagged, resolving mismatches in UPRN ranking and improving data accuracy for address matching. Fixes bug [#29849](https://dev.azure.com/NELAnalytics/LondonDataService/_workitems/edit/29849)
+
+### Inputs
+
+This changelog was automatically produced from:
+
+- 4 Pull Requests
+- 0 Issues
+- 1 WorkItems
+- 7 Commits
+
+## Full Details
+
+Pull Requests included in this release:
+- [PR #44](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/44): Change release pipeline so amended views default is true
+  - No linked issues.
+- [PR #46](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/46): Bug 29849 - correct uprn ranking mismatch
+  - [WorkItem AB#29849](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29849)
+- [PR #47](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/47): Remove PUBLISHER_ORGANISATION_CODE from query
+  - No linked issues.
+- [PR #48](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/pull/48): Update revision for EMIS_OLIDS to V1.2.0
+  - No linked issues.
+
+[View the diff between V1.1.0 and V1.2.0](https://github.com/NHSISL/LondonDataservices.Transform.OLIDS_Enrichment/compare/releases%2FV1.1.0...releases%2FV1.2.0)


### PR DESCRIPTION
Add release notes for OLIDS:
- OLIDS_Share (no change)
- EMIS_OLIDS => v1.2.0
- OLIDS_Enrichment => v1.2.0
